### PR TITLE
fix: use valid package name in create-pellicule template

### DIFF
--- a/packages/create-pellicule/src/index.js
+++ b/packages/create-pellicule/src/index.js
@@ -60,7 +60,7 @@ function copyTemplate(templateDir, targetDir, projectName) {
     let content = readFileSync(srcPath, 'utf-8')
 
     // Replace template variables
-    content = content.replace(/\{\{name\}\}/g, projectName)
+    content = content.replace(/my-pellicule-video/g, projectName)
 
     writeFileSync(destPath, content)
   }

--- a/packages/create-pellicule/template/package.json
+++ b/packages/create-pellicule/template/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "{{name}}",
+  "name": "my-pellicule-video",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Replace {{name}} placeholder with my-pellicule-video to fix IDE JSON schema validation warnings. The CLI now replaces this valid name with the actual project name during scaffolding.

Closes #15