### PR TITLE
feat: add audio support (--audio flag)

### DIFF
--- a/packages/core/bin/cli.js
+++ b/packages/core/bin/cli.js
@@ -56,6 +56,7 @@ ${c.bold('OPTIONS')}
   ${c.info('-w, --width')} <pixels>    Video width ${c.dim('(default: from component or 1920)')}
   ${c.info('-h, --height')} <pixels>   Video height ${c.dim('(default: from component or 1080)')}
   ${c.info('-r, --range')} <start:end> Frame range for partial render ${c.dim('(e.g., 100:200)')}
+  ${c.info('-a, --audio')} <file>     Audio file to include ${c.dim('(mp3, wav, aac, etc.)')}
   ${c.info('--help')}                 Show this help message
   ${c.info('--version')}               Show version number
 
@@ -123,6 +124,7 @@ async function main() {
       width: { type: 'string', short: 'w' },
       height: { type: 'string', short: 'h' },
       range: { type: 'string', short: 'r' },
+      audio: { type: 'string', short: 'a' },
       help: { type: 'boolean' },
       version: { type: 'boolean' }
     }
@@ -157,6 +159,17 @@ async function main() {
 
   // Extract config from component (if defineVideoConfig is used)
   const componentConfig = extractVideoConfig(inputPath)
+
+  // Resolve audio file path (CLI flag takes precedence over component config)
+  let audioPath = null
+  if (values.audio) {
+    audioPath = resolve(values.audio)
+    if (!existsSync(audioPath)) fail(`Audio file not found: ${values.audio}`)
+  } else if (componentConfig?.audio) {
+    // Resolve component audio path relative to the component file
+    audioPath = resolve(dirname(inputPath), componentConfig.audio)
+    if (!existsSync(audioPath)) fail(`Audio file not found: ${componentConfig.audio}`)
+  }
 
   // Build CLI flags object (only include explicitly provided values)
   const cliFlags = {}
@@ -215,6 +228,9 @@ async function main() {
   if (isPartialRender) {
     console.log(`  ${c.bold('Range')}      ${c.highlight(`frames ${startFrame}-${endFrame - 1}`)} ${c.dim(`(${framesToRender} frames, ${partialSeconds}s)`)}`)
   }
+  if (audioPath) {
+    console.log(`  ${c.bold('Audio')}      ${c.info(basename(audioPath))}`)
+  }
   console.log()
 
   const startTime = Date.now()
@@ -234,6 +250,7 @@ async function main() {
       width,
       height,
       output: outputPath,
+      audio: audioPath,
       silent: true,
       onProgress: ({ frame, total, fps: currentFps }) => {
         // Clear line and print progress (stays on same line)

--- a/packages/core/src/renderer/encode.js
+++ b/packages/core/src/renderer/encode.js
@@ -8,6 +8,7 @@ import path from 'path'
  * @param {string} options.framesDir - Directory containing frame-XXXXX.png files
  * @param {string} options.output - Output video path (default: './output.mp4')
  * @param {number} options.fps - Frames per second (default: 30)
+ * @param {string|null} options.audio - Audio file path to include (default: null)
  * @param {boolean} options.silent - Suppress console output (default: false)
  * @returns {Promise<string>} Path to the output video
  */
@@ -16,6 +17,7 @@ export function encodeVideo(options) {
     framesDir,
     output = './output.mp4',
     fps = 30,
+    audio = null,
     silent = false
   } = options
 
@@ -26,9 +28,11 @@ export function encodeVideo(options) {
       '-y', // Overwrite output
       '-framerate', String(fps),
       '-i', framePattern,
+      ...(audio ? ['-i', audio] : []),
       '-c:v', 'libx264',
       '-pix_fmt', 'yuv420p', // Compatibility
       '-preset', 'fast',
+      ...(audio ? ['-c:a', 'aac'] : []),
       output
     ]
 
@@ -72,13 +76,14 @@ export function encodeVideo(options) {
  * Full render pipeline: Vue component → frames → MP4
  *
  * @param {object} options - Same as renderVideo, plus output path
+ * @param {string|null} options.audio - Audio file path to include (default: null)
  * @param {boolean} options.silent - Suppress console output (default: false)
  * @returns {Promise<string>} Path to the output video
  */
 export async function renderToMp4(options) {
   const { renderVideo } = await import('./render.js')
 
-  const { output = './output.mp4', silent = false, ...renderOptions } = options
+  const { output = './output.mp4', audio = null, silent = false, ...renderOptions } = options
 
   // Step 1: Render frames (stored in .pellicule/frames)
   const { framesDir, cleanup } = await renderVideo({ ...renderOptions, silent })
@@ -89,6 +94,7 @@ export async function renderToMp4(options) {
       framesDir,
       output,
       fps: renderOptions.fps || 30,
+      audio,
       silent
     })
 


### PR DESCRIPTION
Add support for including audio files in rendered videos via:
- CLI flag: --audio / -a
- defineVideoConfig: audio property

Audio is re-encoded to AAC for universal MP4 compatibility. Video duration remains the source of truth (no -shortest flag).

Closes #18