### PR TITLE
Improve render readiness, config refresh, and editor support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run typecheck
+        run: npm run typecheck

--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -1,0 +1,63 @@
+# Skills Example Test Notes
+
+Use this example to verify two behaviors:
+
+1. Pellicule waits for DOM assets before declaring the frame ready.
+2. `pellicule dev` refreshes preview timing when `defineVideoConfig()` changes.
+
+## Setup
+
+```bash
+cd examples/skills
+npm install
+```
+
+## Manual verification
+
+### 1. Preview config refresh
+
+Start preview:
+
+```bash
+npm run dev
+```
+
+Then edit `Video.vue` and change:
+
+```js
+durationInSeconds: 8
+```
+
+to:
+
+```js
+durationInSeconds: 10
+```
+
+Expected result:
+
+- The preview page reloads automatically.
+- The overlay updates from `239` total frames / `8.00s` to `299` total frames / `10.00s`.
+- The timeline scrubber max updates with the new duration.
+
+Change the value back to `8` and confirm the preview shrinks again.
+
+### 2. Asset readiness during render
+
+Render the example:
+
+```bash
+npm run render
+```
+
+Expected result:
+
+- The output renders successfully to `skills-demo.mp4`.
+- The first visible frames already contain the Claude Code logo image from `assets/claude-code-logo.png`.
+- There should be no missing-image flash at the start of the video.
+
+## What this does not verify
+
+- It does not infer duration from scene count automatically.
+- If you add more scenes but do not update `defineVideoConfig()`, Pellicule still uses the configured duration.
+

--- a/examples/skills/Video.vue
+++ b/examples/skills/Video.vue
@@ -1,6 +1,6 @@
 <script setup>
 defineVideoConfig({
-  durationInSeconds: 8
+  durationInSeconds: 10
 })
 
 import { computed } from 'vue'
@@ -10,13 +10,13 @@ const frame = useFrame()
 const { fps } = useVideoConfig()
 
 // =============================================================================
-// SCENE TIMING (8 seconds = 240 frames at 30fps)
+// SCENE TIMING (10 seconds = 300 frames at 30fps)
 // =============================================================================
 const SCENE = {
   terminal: { start: 0, end: fps * 5 },           // 0-5s: Terminal typing + SKILLS banner
   announce: { start: fps * 5, end: fps * 6.5 },   // 5-6.5s: Announcement
-  logos: { start: fps * 6.5, end: fps * 7.5 },    // 6.5-7.5s: Logos
-  final: { start: fps * 7.5, end: fps * 8 }       // 7.5-8s: Final logo mark
+  logos: { start: fps * 6.5, end: fps * 9.1 },    // 6.5-9.1s: Claude hold, Codex push, Codex hold
+  final: { start: fps * 9.1, end: fps * 10 }      // 9.1-10s: Final logo mark
 }
 
 const currentScene = computed(() => {
@@ -38,7 +38,7 @@ const orb2Y = computed(() => Math.sin(frame.value * 0.022) * 100)
 // =============================================================================
 // SCENE 1: TERMINAL - Fast typing, then ASCII banner
 // =============================================================================
-const command = 'npx skills add sailscastshq/pellicule-skills'
+const command = 'npx skills add sailscastshq/pellicule/skills'
 
 // FAST typing - 1 char per frame, starts at frame 15
 const typingStart = fps * 0.5
@@ -121,15 +121,34 @@ const logosScale = computed(() =>
 )
 
 const pelliculeX = computed(() =>
-  interpolate(frame.value, [SCENE.logos.start, SCENE.logos.start + fps * 0.35], [-150, 0], { easing: Easing.easeOut })
+  interpolate(frame.value, [SCENE.logos.start, SCENE.logos.start + fps * 0.35], [-220, 0], { easing: Easing.easeOut })
 )
 
-const claudeX = computed(() =>
-  interpolate(frame.value, [SCENE.logos.start, SCENE.logos.start + fps * 0.35], [150, 0], { easing: Easing.easeOut })
+const partnerLogoX = computed(() =>
+  interpolate(frame.value, [SCENE.logos.start, SCENE.logos.start + fps * 0.35], [220, 0], { easing: Easing.easeOut })
+)
+
+const handoffStart = SCENE.logos.start + fps * 0.75
+const handoffEnd = SCENE.logos.start + fps * 1.2
+
+const codexY = computed(() =>
+  interpolate(frame.value, [handoffStart, handoffEnd], [-320, 0], { easing: Easing.easeInOut })
+)
+
+const codexScale = computed(() =>
+  interpolate(frame.value, [handoffStart, handoffEnd], [0.96, 1], { easing: Easing.easeOut })
+)
+
+const claudeY = computed(() =>
+  interpolate(frame.value, [handoffStart, handoffEnd], [0, 320], { easing: Easing.easeInOut })
+)
+
+const claudeScale = computed(() =>
+  interpolate(frame.value, [handoffStart, handoffEnd], [1, 0.98], { easing: Easing.easeInOut })
 )
 
 const logosFadeOut = computed(() =>
-  interpolate(frame.value, [SCENE.logos.end - fps * 0.15, SCENE.logos.end], [1, 0])
+  interpolate(frame.value, [SCENE.logos.end - fps * 0.2, SCENE.logos.end], [1, 0])
 )
 
 // Plus sign rotation
@@ -238,7 +257,7 @@ const skillsBanner = `███████╗██╗  ██╗██╗█�
             </div>
             <div class="output-line">
               <span class="diamond">◇</span>
-              <span>Source: <span class="url">github.com/sailscastshq/pellicule-skills</span></span>
+              <span>Source: <span class="url">github.com/sailscastshq/pellicule/tree/main/skills</span></span>
             </div>
             <div class="output-line highlight">
               <span class="bullet">●</span>
@@ -266,7 +285,7 @@ const skillsBanner = `███████╗██╗  ██╗██╗█�
       <h1 :style="{ textShadow: `0 0 ${80 * glowPulse}px rgba(66, 184, 131, ${glowPulse})` }">
         Pellicule Skills
       </h1>
-      <p>now available for Claude Code</p>
+      <p>now available for Claude Code and Codex</p>
     </div>
 
     <!-- ================================================================== -->
@@ -289,14 +308,27 @@ const skillsBanner = `███████╗██╗  ██╗██╗█�
       </div>
 
       <span
-        class="plus"
+        class="logo-connector"
         :style="{ transform: `rotate(${plusRotation}deg)` }"
-      >+</span>
+      >×</span>
 
-      <!-- Claude Code Logo - using image -->
-      <div class="logo-item" :style="{ transform: `translateX(${claudeX}px)` }">
-        <div class="claude-logo">
+      <div class="partner-logo-stack" :style="{ transform: `translateX(${partnerLogoX}px)` }">
+        <div
+          class="logo-item claude-logo"
+          :style="{
+            transform: `translateY(${claudeY}px) scale(${claudeScale})`
+          }"
+        >
           <img src="./assets/claude-code-logo.png" alt="Claude Code" class="logo-img" />
+        </div>
+
+        <div
+          class="logo-item codex-logo"
+          :style="{
+            transform: `translateY(${codexY}px) scale(${codexScale})`
+          }"
+        >
+          <img src="./assets/codex-logo.svg" alt="Codex" class="logo-img codex-img" />
         </div>
       </div>
     </div>
@@ -580,13 +612,14 @@ const skillsBanner = `███████╗██╗  ██╗██╗█�
 .logos-scene {
   display: flex;
   align-items: center;
-  gap: 120px;
+  gap: 72px;
   z-index: 1;
 }
 
 .logo-item {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .pellicule-logo {
@@ -607,21 +640,43 @@ const skillsBanner = `███████╗██╗  ██╗██╗█�
   background: linear-gradient(180deg, #42b883 0%, #1a3a4a 100%);
 }
 
-.plus {
-  font-size: 100px;
+.logo-connector {
+  font-size: 84px;
   font-weight: 300;
   color: rgba(255, 255, 255, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.partner-logo-stack {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+}
+
+.partner-logo-stack .logo-item {
+  position: absolute;
+  inset: 0;
 }
 
 .claude-logo {
-  display: flex;
-  align-items: center;
+  z-index: 1;
+}
+
+.codex-logo {
+  z-index: 2;
 }
 
 .logo-img {
   height: 220px;
   width: auto;
   filter: drop-shadow(0 20px 40px rgba(0, 0, 0, 0.4));
+}
+
+.codex-img {
+  height: 250px;
 }
 
 /* ==========================================================================

--- a/examples/skills/assets/codex-logo.svg
+++ b/examples/skills/assets/codex-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title">
+  <title>Codex</title>
+  <defs>
+    <linearGradient id="codexGradient" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#b3a8ff" />
+      <stop offset="55%" stop-color="#7f95f4" />
+      <stop offset="100%" stop-color="#4850f3" />
+    </linearGradient>
+  </defs>
+  <g fill="url(#codexGradient)">
+    <circle cx="165" cy="256" r="118" />
+    <circle cx="250" cy="164" r="112" />
+    <circle cx="337" cy="198" r="102" />
+    <circle cx="383" cy="280" r="117" />
+    <circle cx="286" cy="359" r="123" />
+    <circle cx="194" cy="340" r="112" />
+  </g>
+  <g fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M182 221 L231 298 L182 379" stroke-width="28" />
+    <path d="M272 379 H362" stroke-width="24" />
+  </g>
+</svg>

--- a/examples/skills/package-lock.json
+++ b/examples/skills/package-lock.json
@@ -1,0 +1,319 @@
+{
+  "name": "pellicule-skills-demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pellicule-skills-demo",
+      "dependencies": {
+        "pellicule": "file:../../packages/core",
+        "vue": "^3.5.13"
+      }
+    },
+    "../../packages/core": {
+      "name": "pellicule",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@vitejs/plugin-vue": "^5.0.0",
+        "playwright": "^1.40.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "pellicule": "bin/cli.js"
+      },
+      "devDependencies": {
+        "@nuxt/kit": "^4.3.0"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": "^3.0.0",
+        "@rsbuild/core": "^1.0.0",
+        "@rsbuild/plugin-vue": "^1.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "@rsbuild/core": {
+          "optional": true
+        },
+        "@rsbuild/plugin-vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pellicule": {
+      "resolved": "../../packages/core",
+      "link": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/skills/package.json
+++ b/examples/skills/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "render": "npx pellicule Video.vue -d 240 -o skills-demo.mp4"
+    "dev": "npx pellicule dev",
+    "render": "npx pellicule Video.vue -d 300 -o skills-demo.mp4"
   },
   "dependencies": {
-    "pellicule": "*",
+    "pellicule": "file:../../packages/core",
     "vue": "^3.5.13"
   }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,67 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
+    "baseUrl": ".",
+    "lib": [
+      "ES2023",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "types": [
+      "node"
+    ],
+    "paths": {
+      "pellicule": [
+        "packages/core/src/index.js"
+      ],
+      "pellicule/render": [
+        "packages/core/src/render.js"
+      ],
+      "pellicule/runtime/*": [
+        "packages/core/src/runtime/*"
+      ],
+      "pellicule/nuxt": [
+        "packages/core/src/nuxt/module.js"
+      ],
+      "pellicule/quasar": [
+        "packages/core/src/quasar/index.js"
+      ]
+    }
+  },
+  "include": [
+    "packages/core/bin/**/*.js",
+    "packages/core/src/bundler/**/*.js",
+    "packages/core/src/composables/**/*.js",
+    "packages/core/src/config/**/*.js",
+    "packages/core/src/define-video-config.js",
+    "packages/core/src/dev/overlay.js",
+    "packages/core/src/dev/server.js",
+    "packages/core/src/globals.js",
+    "packages/core/src/index.js",
+    "packages/core/src/macros/**/*.js",
+    "packages/core/src/render.js",
+    "packages/core/src/renderer/**/*.js",
+    "packages/core/src/runtime/**/*.js",
+    "packages/core/src/types.js",
+    "packages/core/src/utils/**/*.js",
+    "packages/core/test/**/*.js",
+    "examples/**/*.js",
+    "examples/**/*.vue"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/.pellicule",
+    "packages/core/src/nuxt/**",
+    "packages/core/src/quasar/**",
+    "packages/create-pellicule/**"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,11 @@
       "name": "pellicule-monorepo",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "@types/node": "^25.9.1",
+        "typescript": "^6.0.3"
+      }
     },
     "examples/basic": {
       "name": "pellicule-example-basic",
@@ -847,6 +851,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -1581,6 +1595,20 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -1610,6 +1638,13 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unplugin": {
       "version": "2.3.11",
@@ -1760,7 +1795,7 @@
     },
     "packages/core": {
       "name": "pellicule",
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@vitejs/plugin-vue": "^5.0.0",
@@ -1792,7 +1827,7 @@
       }
     },
     "packages/create-pellicule": {
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "bin": {
         "create-pellicule": "src/index.js"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   ],
   "scripts": {
     "pellicule": "node packages/core/bin/cli.js",
-    "example:pellicule": "cd examples/pellicule && npm run render"
+    "example:pellicule": "cd examples/pellicule && npm run render",
+    "test": "node --test \"packages/core/test/**/*.test.js\"",
+    "typecheck": "tsc -p jsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/core/bin/cli.js
+++ b/packages/core/bin/cli.js
@@ -9,8 +9,20 @@ import { extractVideoConfig, resolveVideoConfig } from '../src/macros/define-vid
 import { detectProject, readPelliculeConfig, resolveInputFile } from '../src/config/detect.js'
 import { startDevServer } from '../src/dev/server.js'
 
+/**
+ * @typedef {import('../src/types.js').BundlerName} BundlerName
+ * @typedef {import('../src/types.js').CliVideoConfigFlags} CliVideoConfigFlags
+ * @typedef {import('../src/types.js').DetectedProject} DetectedProject
+ * @typedef {import('../src/types.js').InputResolutionFailure} InputResolutionFailure
+ * @typedef {import('../src/types.js').InputResolutionSuccess} InputResolutionSuccess
+ * @typedef {import('../src/types.js').ProjectType} ProjectType
+ * @typedef {import('../src/types.js').RenderProgress} RenderProgress
+ * @typedef {import('../src/types.js').VideoConfigLiteral} VideoConfigLiteral
+ */
+
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url))
+/** @type {{ version: string }} */
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'))
 const VERSION = pkg.version
 
@@ -28,15 +40,27 @@ const colors = {
 }
 
 const c = {
+  /** @param {string} s */
   error: (s) => `${colors.red}${s}${colors.reset}`,
+  /** @param {string} s */
   warn: (s) => `${colors.yellow}${s}${colors.reset}`,
+  /** @param {string} s */
   info: (s) => `${colors.cyan}${s}${colors.reset}`,
+  /** @param {string} s */
   dim: (s) => `${colors.dim}${s}${colors.reset}`,
+  /** @param {string} s */
   bold: (s) => `${colors.bold}${s}${colors.reset}`,
+  /** @param {string} s */
   highlight: (s) => `${colors.pellicule}${s}${colors.reset}`,
+  /** @param {string} s */
   brand: (s) => `${colors.bgPellicule}${colors.white}${colors.bold}${s}${colors.reset}`
 }
 
+/**
+ * @param {string} msg
+ * @param {string} [hint]
+ * @returns {never}
+ */
 function fail(msg, hint) {
   console.error(c.error(`\nError: ${msg}\n`))
   if (hint) console.error(c.dim(`  ${hint}\n`))
@@ -138,12 +162,22 @@ function printBanner() {
   console.log()
 }
 
+/**
+ * @param {number} ms
+ * @returns {string}
+ */
 function formatTime(ms) {
   if (ms < 1000) return `${ms}ms`
   const seconds = (ms / 1000).toFixed(1)
   return `${seconds}s`
 }
 
+/**
+ * @param {number} frame
+ * @param {number} total
+ * @param {number} fps
+ * @returns {string}
+ */
 function formatProgress(frame, total, fps) {
   const percent = Math.round(((frame + 1) / total) * 100)
   const barWidth = 30
@@ -151,6 +185,34 @@ function formatProgress(frame, total, fps) {
   const empty = barWidth - filled
   const bar = c.highlight('█'.repeat(filled)) + c.dim('░'.repeat(empty))
   return `  ${bar} ${c.bold(percent + '%')} ${c.dim(`(${frame + 1}/${total} @ ${fps.toFixed(1)} fps)`)}`
+}
+
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * @param {string | undefined} value
+ * @returns {BundlerName | undefined}
+ */
+function parseBundlerName(value) {
+  if (value === 'vite' || value === 'rsbuild') {
+    return value
+  }
+
+  return undefined
+}
+
+/**
+ * @param {import('../src/config/detect.js').resolveInputFile extends (...args: any[]) => infer R ? R : never} result
+ * @returns {result is InputResolutionFailure}
+ */
+function isInputResolutionFailure(result) {
+  return 'error' in result
 }
 
 async function main() {
@@ -194,24 +256,27 @@ async function main() {
   const pkgConfig = readPelliculeConfig()
 
   // Resolution: CLI flags > package.json "pellicule" key > auto-detected
-  const bundler = values.bundler || pkgConfig.bundler || detected.bundler
+  const cliBundler = parseBundlerName(values.bundler)
+  const bundler = cliBundler || pkgConfig.bundler || detected.bundler
   const configFile = values.config ? resolve(values.config) : detected.configFile
   const videosDir = values['videos-dir'] ? resolve(values['videos-dir']) : pkgConfig.videosDir || detected.videosDir
   const outDir = values['out-dir'] ? resolve(values['out-dir']) : pkgConfig.outDir || null
   const serverUrl = values['server-url'] || pkgConfig.serverUrl || detected.defaultServerUrl || null
   const projectType = detected.projectType
 
+  /** @type {Partial<Record<ProjectType, string>>} */
   const projectLabels = {
     laravel: 'Laravel',
     vite: 'Vite',
     rsbuild: 'Rsbuild',
     shipwright: 'Boring Stack (Shipwright)',
     nuxt: 'Nuxt',
-    quasar: 'Quasar'
+    quasar: 'Quasar',
+    standalone: 'Standalone'
   }
 
   // Validate bundler flag
-  if (values.bundler && !['vite', 'rsbuild'].includes(values.bundler)) {
+  if (values.bundler && !cliBundler) {
     fail(`Unknown bundler: ${values.bundler}`, 'Supported bundlers: vite, rsbuild')
   }
 
@@ -219,8 +284,8 @@ async function main() {
   const input = positionals[0] || 'Video.vue'
   const result = resolveInputFile(input, videosDir)
 
-  if (result.error) {
-    const searchedPaths = result.searched.map(p => `  - ${p}`).join('\n')
+  if (isInputResolutionFailure(result)) {
+    const searchedPaths = result.searched.map((searchedPath) => `  - ${searchedPath}`).join('\n')
     fail(result.error, `Looked in:\n${searchedPaths}`)
   }
 
@@ -234,6 +299,7 @@ async function main() {
   const componentConfig = extractVideoConfig(inputPath)
 
   // Resolve audio file path (CLI flag takes precedence over component config)
+  /** @type {string | null} */
   let audioPath = null
   if (values.audio) {
     audioPath = resolve(values.audio)
@@ -245,6 +311,7 @@ async function main() {
   }
 
   // Build CLI flags object (only include explicitly provided values)
+  /** @type {CliVideoConfigFlags} */
   const cliFlags = {}
   if (values.duration !== undefined) cliFlags.duration = parseInt(values.duration, 10)
   if (values.fps !== undefined) cliFlags.fps = parseInt(values.fps, 10)
@@ -329,6 +396,12 @@ async function main() {
         height,
         serverUrl: devServerUrl,
         bundler,
+        syncConfigWithComponent: (
+          values.duration === undefined &&
+          values.fps === undefined &&
+          values.width === undefined &&
+          values.height === undefined
+        ),
         configFile,
         projectType,
         version: VERSION
@@ -343,7 +416,7 @@ async function main() {
       // Keep process alive
       await new Promise(() => {})
     } catch (error) {
-      console.error(c.error(`  Error: ${error.message}`))
+      console.error(c.error(`  Error: ${getErrorMessage(error)}`))
       process.exit(1)
     }
   }
@@ -429,16 +502,17 @@ async function main() {
     // Clear progress line on error
     process.stdout.write(clearLine + cursorToStart)
     console.error()
-    console.error(c.error(`  Error: ${error.message}`))
+    const message = getErrorMessage(error)
+    console.error(c.error(`  Error: ${message}`))
     console.error()
 
-    if (error.message.includes('ffmpeg')) {
+    if (message.includes('ffmpeg')) {
       console.error(c.warn('  Hint: Make sure FFmpeg is installed and available in your PATH'))
       console.error(c.dim('  Install: https://ffmpeg.org/download.html'))
       console.error()
     }
 
-    if (error.message.includes('Rsbuild')) {
+    if (message.includes('Rsbuild')) {
       console.error(c.warn('  Hint: Install @rsbuild/core and @rsbuild/plugin-vue'))
       console.error(c.dim('  npm install -D @rsbuild/core @rsbuild/plugin-vue'))
       console.error()
@@ -449,6 +523,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(c.error(`\nUnexpected error: ${error.message}\n`))
+  console.error(c.error(`\nUnexpected error: ${getErrorMessage(error)}\n`))
   process.exit(1)
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,8 @@
   "exports": {
     ".": "./src/index.js",
     "./render": "./src/render.js",
+    "./runtime/config": "./src/runtime/config.js",
+    "./runtime/ready": "./src/runtime/ready.js",
     "./nuxt": "./src/nuxt/module.js",
     "./quasar": "./src/quasar/index.js"
   },

--- a/packages/core/src/bundler/entry.js
+++ b/packages/core/src/bundler/entry.js
@@ -104,33 +104,51 @@ export function generateHtml({ width = 1920, height = 1080, preview = false, fps
  * @param {string} options.componentPath - Relative path from the temp dir to the .vue file
  * @param {number} options.width
  * @param {number} options.height
+ * @param {boolean} [options.preview] - Whether the entry is used for dev preview
  * @returns {string}
  */
-export function generateEntryJs({ componentPath, width = 1920, height = 1080 }) {
+export function generateEntryJs({ componentPath, width = 1920, height = 1080, preview = false }) {
   return `
 import { createApp, ref, provide, h, nextTick } from 'vue'
 import VideoComponent from '${componentPath}'
+import { buildVideoConfigUrl, haveVideoConfigChanged, parseVideoConfigFromSearch, resolveVideoConfig } from 'pellicule/runtime/config'
+import { waitForRenderReady } from 'pellicule/runtime/ready'
 
 // Pellicule injection keys (must match composables.js)
 const FRAME_KEY = Symbol.for('pellicule-frame')
 const CONFIG_KEY = Symbol.for('pellicule-config')
 
-// Get initial config from URL
 const params = new URLSearchParams(window.location.search)
-const fps = parseInt(params.get('fps') || '30', 10)
-const durationInFrames = parseInt(params.get('duration') || '90', 10)
-const width = parseInt(params.get('width') || '${width}', 10)
-const height = parseInt(params.get('height') || '${height}', 10)
-
-const config = { fps, durationInFrames, width, height }
+const config = parseVideoConfigFromSearch(window.location.search, {
+  width: ${width},
+  height: ${height}
+})
+const allowPreviewConfigSync = ${preview ? 'true' : 'false'} && params.get('config-refresh') === '1'
+let pendingReload = false
 
 // Frame ref - reactive, will trigger re-render when changed
 const frameRef = ref(0)
+
+globalThis.__PELLICULE_COMPONENT_CONFIG__ = null
+globalThis.__PELLICULE_ON_CONFIG__ = (componentConfig) => {
+  if (!allowPreviewConfigSync || pendingReload) {
+    return
+  }
+
+  const nextConfig = resolveVideoConfig(config, componentConfig)
+  if (!haveVideoConfigChanged(config, nextConfig)) {
+    return
+  }
+
+  pendingReload = true
+  window.location.replace(buildVideoConfigUrl(window.location.href, nextConfig))
+}
 
 // Expose setFrame function for the renderer to call
 window.__PELLICULE_SET_FRAME__ = async (frame) => {
   frameRef.value = frame
   await nextTick() // Wait for Vue to re-render
+  await waitForRenderReady()
 }
 
 try {
@@ -144,7 +162,12 @@ try {
   })
 
   app.mount('#app')
-  window.__PELLICULE_READY__ = true
+
+  if (!pendingReload) {
+    await nextTick()
+    await waitForRenderReady()
+    window.__PELLICULE_READY__ = true
+  }
 } catch (error) {
   console.error('Pellicule render error:', error)
   window.__PELLICULE_READY__ = true
@@ -177,7 +200,8 @@ export async function writeTempEntry({ inputPath, width = 1920, height = 1080, p
   const js = generateEntryJs({
     componentPath: `../${inputFile}`,
     width,
-    height
+    height,
+    preview
   })
 
   await writeFile(join(tempDir, 'index.html'), html)

--- a/packages/core/src/bundler/rsbuild.js
+++ b/packages/core/src/bundler/rsbuild.js
@@ -18,6 +18,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const pelliculeSrc = resolve(__dirname, '..')
 
 /**
+ * @typedef {import('../types.js').BundlerServerResult} BundlerServerResult
+ * @typedef {import('../types.js').BundlerServerOptions} BundlerServerOptions
+ */
+
+/**
  * Load the user's Rsbuild config from a config file.
  *
  * For Shipwright configs, reads config/shipwright.js and
@@ -36,6 +41,7 @@ async function loadUserConfig(configFile, projectType) {
   }
 
   // Standalone rsbuild.config.js — use Rsbuild's own config loader
+  // @ts-expect-error Rsbuild is an optional peer dependency and may not be installed in this workspace.
   const { loadConfig } = await import('@rsbuild/core')
   const { content } = await loadConfig({ cwd: dirname(configFile) })
   return content || {}
@@ -44,17 +50,8 @@ async function loadUserConfig(configFile, projectType) {
 /**
  * Creates an Rsbuild dev server for rendering a video component.
  *
- * @param {object} options
- * @param {string} options.input - Absolute path to the .vue file
- * @param {number} options.width - Video width
- * @param {number} options.height - Video height
- * @param {string|null} [options.configFile] - Path to the user's config file
- * @param {'rsbuild'|'shipwright'} [options.projectType] - Which config format to read
- * @param {boolean} [options.preview] - Whether to inject the dev preview overlay
- * @param {number} [options.fps] - FPS (passed to overlay when preview=true)
- * @param {number} [options.durationInFrames] - Total frames (passed to overlay when preview=true)
- * @param {string} [options.version] - Package version (shown in overlay)
- * @returns {Promise<{ server: object, url: string, cleanup: function, tempDir: string }>}
+ * @param {BundlerServerOptions} options
+ * @returns {Promise<BundlerServerResult>}
  */
 export async function createVideoServer(options) {
   const {
@@ -74,7 +71,10 @@ export async function createVideoServer(options) {
   // resolves relative to the file's physical location, not the project root.
   const projectRequire = createRequire(resolve(process.cwd(), 'package.json'))
 
-  let createRsbuild, mergeRsbuildConfig
+  /** @type {((options: { rsbuildConfig: object }) => Promise<any>) | undefined} */
+  let createRsbuild
+  /** @type {((base: object, extra: object) => object) | undefined} */
+  let mergeRsbuildConfig
   try {
     const rsbuildCorePath = projectRequire.resolve('@rsbuild/core')
     const rsbuildCore = await import(rsbuildCorePath)
@@ -102,6 +102,7 @@ export async function createVideoServer(options) {
   })
 
   // Load @rsbuild/plugin-vue (also resolved from user's project)
+  /** @type {(() => any) | undefined} */
   let pluginVue
   try {
     const pluginVuePath = projectRequire.resolve('@rsbuild/plugin-vue')
@@ -114,6 +115,10 @@ export async function createVideoServer(options) {
     )
   }
 
+  if (!createRsbuild || !pluginVue) {
+    throw new Error('Rsbuild helpers were not loaded correctly')
+  }
+
   // Build resolve.alias — always alias 'pellicule' to the local source.
   // Also alias 'vue' to the project's Vue to avoid duplicate Vue runtimes.
   // Without this, pellicule's source files (physically located in the pellicule
@@ -122,6 +127,7 @@ export async function createVideoServer(options) {
   // Vue instances means provide/inject breaks silently.
   // For Shipwright projects, also add the conventional ~ and @ aliases
   // that sails-hook-shipwright normally injects at runtime.
+  /** @type {Record<string, string>} */
   const aliases = {
     'pellicule': pelliculeSrc,
     'vue': projectRequire.resolve('vue')
@@ -163,13 +169,17 @@ export async function createVideoServer(options) {
 
   let finalConfig = pelliculeConfig
 
+  const rsbuildProjectType = projectType === 'shipwright' ? 'shipwright' : 'rsbuild'
+
   // If the user has a config file, load and merge it
   if (configFile) {
-    const userConfig = await loadUserConfig(configFile, projectType)
+    const userConfig = await loadUserConfig(configFile, rsbuildProjectType)
 
     if (userConfig && Object.keys(userConfig).length > 0) {
       // User config is the base, Pellicule config merges on top
-      finalConfig = mergeRsbuildConfig(userConfig, pelliculeConfig)
+      finalConfig = mergeRsbuildConfig
+        ? mergeRsbuildConfig(userConfig, pelliculeConfig)
+        : pelliculeConfig
     }
   }
 

--- a/packages/core/src/bundler/vite.js
+++ b/packages/core/src/bundler/vite.js
@@ -10,6 +10,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const pelliculeSrc = resolve(__dirname, '..')
 
 /**
+ * @typedef {import('net').AddressInfo} AddressInfo
+ * @typedef {import('vite').InlineConfig} InlineConfig
+ * @typedef {import('vite').PluginOption} VitePluginOption
+ * @typedef {import('../types.js').BundlerServerResult} BundlerServerResult
+ * @typedef {import('../types.js').BundlerServerOptions} BundlerServerOptions
+ */
+
+/**
  * Creates a Vite dev server for rendering a video component.
  *
  * When a configFile is provided, Pellicule loads the user's existing
@@ -17,16 +25,8 @@ const pelliculeSrc = resolve(__dirname, '..')
  * This means aliases, plugins, and settings from the user's project
  * are automatically available inside video components.
  *
- * @param {object} options
- * @param {string} options.input - Absolute path to the .vue file
- * @param {number} options.width - Video width
- * @param {number} options.height - Video height
- * @param {string|null} [options.configFile] - Path to the user's vite.config.js (auto-detected or explicit)
- * @param {boolean} [options.preview] - Whether to inject the dev preview overlay
- * @param {number} [options.fps] - FPS (passed to overlay when preview=true)
- * @param {number} [options.durationInFrames] - Total frames (passed to overlay when preview=true)
- * @param {string} [options.version] - Package version (shown in overlay)
- * @returns {Promise<{ server: object, url: string, cleanup: function, tempDir: string }>}
+ * @param {BundlerServerOptions} options
+ * @returns {Promise<BundlerServerResult>}
  */
 export async function createVideoServer(options) {
   const { input, width = 1920, height = 1080, configFile = null, preview = false, fps = 30, durationInFrames = 90, version = '' } = options
@@ -49,6 +49,7 @@ export async function createVideoServer(options) {
   // would resolve 'vue' from their own node_modules — different instance
   // than the project's Vue, which breaks provide/inject silently.
   const projectRequire = createRequire(resolve(process.cwd(), 'package.json'))
+  /** @type {string | undefined} */
   let vueAlias
   try {
     vueAlias = projectRequire.resolve('vue')
@@ -56,6 +57,7 @@ export async function createVideoServer(options) {
     // If vue can't be resolved from project, let Vite handle it naturally
   }
 
+  /** @type {Record<string, string>} */
   const aliases = {
     'pellicule': pelliculeSrc
   }
@@ -65,9 +67,11 @@ export async function createVideoServer(options) {
   // plugins. Adding ours too causes a duplicate plugin conflict — the second
   // vue() sees already-transformed output and fails. So we only add vue()
   // when there's no user config (standalone pellicule rendering).
+  /** @type {InlineConfig} */
   let finalConfig
 
   if (configFile) {
+    /** @type {Awaited<ReturnType<typeof loadConfigFromFile>> | null} */
     let loaded = null
     try {
       loaded = await loadConfigFromFile(
@@ -79,9 +83,10 @@ export async function createVideoServer(options) {
       // Fall through to the fallback path below.
     }
 
+    /** @type {InlineConfig} */
     const pelliculeConfig = {
       root: tempDir,
-      plugins: [pelliculeMacroVitePlugin()],
+      plugins: /** @type {VitePluginOption[]} */ ([pelliculeMacroVitePlugin()]),
       server: { port: 0, strictPort: false },
       resolve: { alias: aliases },
       logLevel: 'warn'
@@ -94,18 +99,29 @@ export async function createVideoServer(options) {
       // the Laravel project root.
       if (loaded.config.plugins) {
         const conflicting = new Set(['laravel', 'vite-plugin-full-reload'])
-        loaded.config.plugins = loaded.config.plugins
+        const loadedPlugins = /** @type {any[]} */ (loaded.config.plugins)
+        loaded.config.plugins = /** @type {VitePluginOption[]} */ (loadedPlugins
           .flat(Infinity)
-          .filter(p => !(p && typeof p === 'object' && conflicting.has(p.name)))
+          .filter((plugin) => !(
+            plugin &&
+            typeof plugin === 'object' &&
+            'name' in plugin &&
+            typeof plugin.name === 'string' &&
+            conflicting.has(plugin.name)
+          )))
       }
-      finalConfig = mergeConfig(loaded.config, pelliculeConfig)
+      finalConfig = /** @type {InlineConfig} */ (mergeConfig(loaded.config, pelliculeConfig))
     } else {
       // Config file existed but failed to load — add vue() as fallback
-      pelliculeConfig.plugins.push(vue())
+      pelliculeConfig.plugins = [
+        ...(pelliculeConfig.plugins || []),
+        vue()
+      ]
       finalConfig = pelliculeConfig
     }
   } else {
     // No user config — pellicule provides everything including vue()
+    /** @type {InlineConfig} */
     finalConfig = {
       root: tempDir,
       plugins: [pelliculeMacroVitePlugin(), vue()],
@@ -118,7 +134,11 @@ export async function createVideoServer(options) {
   const server = await createServer(finalConfig)
   await server.listen()
 
-  const address = server.httpServer.address()
+  const address = server.httpServer?.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Vite server did not expose a numeric port')
+  }
+
   const url = `http://localhost:${address.port}`
 
   const cleanup = async () => {

--- a/packages/core/src/composables/frame.js
+++ b/packages/core/src/composables/frame.js
@@ -1,6 +1,8 @@
 import { inject, computed } from 'vue'
 import { FRAME_KEY } from './keys.js'
 
+/** @typedef {import('vue').Ref<number>} FrameRef */
+
 /**
  * Get the current frame number.
  * Must be used within a Pellicule render context.
@@ -12,6 +14,7 @@ import { FRAME_KEY } from './keys.js'
  * const opacity = computed(() => frame.value / 30) // fade in over 1 second at 30fps
  */
 export function useFrame() {
+  /** @type {FrameRef | undefined} */
   const frame = inject(FRAME_KEY)
 
   if (frame === undefined) {

--- a/packages/core/src/composables/keys.js
+++ b/packages/core/src/composables/keys.js
@@ -2,6 +2,9 @@
  * Injection keys for Pellicule context
  * Using Symbol.for() so keys are shared across module instances
  */
+/** @type {symbol} */
 export const FRAME_KEY = Symbol.for('pellicule-frame')
+/** @type {symbol} */
 export const CONFIG_KEY = Symbol.for('pellicule-config')
+/** @type {symbol} */
 export const SEQUENCE_KEY = Symbol.for('pellicule-sequence')

--- a/packages/core/src/composables/sequence.js
+++ b/packages/core/src/composables/sequence.js
@@ -3,6 +3,11 @@ import { SEQUENCE_KEY } from './keys.js'
 import { useFrame } from './frame.js'
 
 /**
+ * @typedef {import('../types.js').SequenceContext} SequenceContext
+ * @typedef {import('../types.js').SequenceProviderContext} SequenceProviderContext
+ */
+
+/**
  * Get sequence timing information.
  * Can be used in two ways:
  *
@@ -11,7 +16,7 @@ import { useFrame } from './frame.js'
  *
  * @param {number} [from] - Start frame (optional if inside <Sequence>)
  * @param {number} [durationInFrames] - Duration in frames (optional if inside <Sequence>)
- * @returns {{ localFrame: ComputedRef<number>, progress: ComputedRef<number>, isActive: ComputedRef<boolean> }}
+ * @returns {SequenceContext}
  *
  * @example
  * // Inside a <Sequence> component
@@ -43,6 +48,7 @@ export function useSequence(from, durationInFrames) {
   }
 
   // Otherwise, try to get from parent <Sequence>
+  /** @type {SequenceProviderContext | null} */
   const sequenceContext = inject(SEQUENCE_KEY, null)
 
   if (!sequenceContext) {
@@ -60,6 +66,7 @@ export function useSequence(from, durationInFrames) {
  *
  * @param {number} from - Start frame
  * @param {number} durationInFrames - Duration in frames
+ * @returns {SequenceProviderContext}
  */
 export function provideSequence(from, durationInFrames) {
   const globalFrame = useFrame()
@@ -75,6 +82,7 @@ export function provideSequence(from, durationInFrames) {
     globalFrame.value >= from && globalFrame.value < end
   )
 
+  /** @type {SequenceProviderContext} */
   const context = { localFrame, progress, isActive, from, durationInFrames }
   provide(SEQUENCE_KEY, context)
 

--- a/packages/core/src/composables/video-config.js
+++ b/packages/core/src/composables/video-config.js
@@ -1,16 +1,19 @@
 import { inject } from 'vue'
 import { CONFIG_KEY } from './keys.js'
 
+/** @typedef {import('../types.js').VideoConfig} VideoConfig */
+
 /**
  * Get the video configuration (fps, duration, dimensions).
  * Must be used within a Pellicule render context.
  *
- * @returns {{ fps: number, durationInFrames: number, width: number, height: number }}
+ * @returns {VideoConfig}
  *
  * @example
  * const { fps, durationInFrames, width, height } = useVideoConfig()
  */
 export function useVideoConfig() {
+  /** @type {VideoConfig | undefined} */
   const config = inject(CONFIG_KEY)
 
   if (!config) {

--- a/packages/core/src/config/detect.js
+++ b/packages/core/src/config/detect.js
@@ -15,15 +15,9 @@ import { existsSync, readFileSync } from 'fs'
 import { join, resolve } from 'path'
 
 /**
- * @typedef {'laravel'|'vite'|'rsbuild'|'shipwright'|'nuxt'|'quasar'|'standalone'} ProjectType
- *
- * @typedef {Object} DetectedProject
- * @property {ProjectType} projectType
- * @property {'vite'|'rsbuild'} bundler - Which bundler adapter to use
- * @property {string|null} configFile - Absolute path to the detected config file
- * @property {string} videosDir - Absolute path to the conventional videos directory
- * @property {boolean} byos - Whether this project requires BYOS (Bring Your Own Server)
- * @property {string|null} defaultServerUrl - Default server URL for BYOS projects (e.g., Nuxt)
+ * @typedef {import('../types.js').DetectedProject} DetectedProject
+ * @typedef {import('../types.js').PelliculeProjectConfig} PelliculeProjectConfig
+ * @typedef {import('../types.js').InputResolutionResult} InputResolutionResult
  */
 
 /**
@@ -155,7 +149,7 @@ export function detectProject(cwd) {
  *   - bundler    — force 'vite' or 'rsbuild'
  *
  * @param {string} [cwd] - Directory to scan (defaults to process.cwd())
- * @returns {{ serverUrl?: string, videosDir?: string, outDir?: string, bundler?: string }}
+ * @returns {PelliculeProjectConfig}
  */
 export function readPelliculeConfig(cwd) {
   const root = resolve(cwd || process.cwd())
@@ -169,11 +163,14 @@ export function readPelliculeConfig(cwd) {
 
     if (!config || typeof config !== 'object') return {}
 
+    /** @type {PelliculeProjectConfig} */
     const result = {}
     if (typeof config.serverUrl === 'string') result.serverUrl = config.serverUrl
     if (typeof config.videosDir === 'string') result.videosDir = resolve(root, config.videosDir)
     if (typeof config.outDir === 'string') result.outDir = resolve(root, config.outDir)
-    if (typeof config.bundler === 'string') result.bundler = config.bundler
+    if (config.bundler === 'vite' || config.bundler === 'rsbuild') {
+      result.bundler = config.bundler
+    }
 
     return result
   } catch {
@@ -192,7 +189,7 @@ export function readPelliculeConfig(cwd) {
  *
  * @param {string} input - User-provided input (e.g., "InvoiceDemo" or "InvoiceDemo.vue")
  * @param {string} videosDir - Conventional videos directory for this project type
- * @returns {{ resolved: string } | { error: string, searched: string[] }}
+ * @returns {InputResolutionResult}
  */
 export function resolveInputFile(input, videosDir) {
   const candidates = []

--- a/packages/core/src/define-video-config.js
+++ b/packages/core/src/define-video-config.js
@@ -1,0 +1,17 @@
+/**
+ * Optional runtime identity helper for Pellicule's compile-time macro.
+ *
+ * Importing this function is not required, but it gives editors an explicit
+ * symbol to attach autocomplete and validation to when an app prefers
+ * imported macros over globals.
+ *
+ * @typedef {import('./types.js').VideoConfigInput} VideoConfigInput
+ */
+
+/**
+ * @param {VideoConfigInput} config
+ * @returns {VideoConfigInput}
+ */
+export function defineVideoConfig(config) {
+  return config
+}

--- a/packages/core/src/dev/overlay.js
+++ b/packages/core/src/dev/overlay.js
@@ -165,11 +165,11 @@ export function generateOverlayScript({ fps = 30, durationInFrames = 90, version
       <button class="po-btn" id="po-next" title="Next frame (→)">${nextIcon}</button>
     </span>
     <span class="po-info">
-      <span id="po-frame">0</span> / ${durationInFrames - 1}
+      <span id="po-frame">0</span> / <span id="po-total">${durationInFrames - 1}</span>
       &nbsp;·&nbsp;
-      <span id="po-time">0.00s</span> / ${(durationInFrames / fps).toFixed(2)}s
+      <span id="po-time">0.00s</span> / <span id="po-total-time">${(durationInFrames / fps).toFixed(2)}s</span>
       &nbsp;·&nbsp;
-      ${fps}fps
+      <span id="po-fps">${fps}</span>fps
     </span>
     <span class="po-kbd">
       <kbd>Space</kbd> play
@@ -182,8 +182,14 @@ export function generateOverlayScript({ fps = 30, durationInFrames = 90, version
 </div>
 <script>
 (function() {
-  var FPS = ${fps};
-  var TOTAL = ${durationInFrames};
+  function parsePositiveInt(value, fallback) {
+    var parsed = parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  var params = new URLSearchParams(window.location.search);
+  var FPS = parsePositiveInt(params.get('fps'), ${fps});
+  var TOTAL = parsePositiveInt(params.get('duration'), ${durationInFrames});
   var FRAME_MS = 1000 / FPS;
 
   var currentFrame = 0;
@@ -192,10 +198,18 @@ export function generateOverlayScript({ fps = 30, durationInFrames = 90, version
 
   var scrubber = document.getElementById('po-scrubber');
   var frameDisplay = document.getElementById('po-frame');
+  var totalDisplay = document.getElementById('po-total');
   var timeDisplay = document.getElementById('po-time');
+  var totalTimeDisplay = document.getElementById('po-total-time');
+  var fpsDisplay = document.getElementById('po-fps');
   var playBtn = document.getElementById('po-play');
   var prevBtn = document.getElementById('po-prev');
   var nextBtn = document.getElementById('po-next');
+
+  scrubber.max = TOTAL - 1;
+  totalDisplay.textContent = TOTAL - 1;
+  totalTimeDisplay.textContent = (TOTAL / FPS).toFixed(2) + 's';
+  fpsDisplay.textContent = FPS;
 
   // Pre-create the SVG DOM nodes for play/pause toggle (avoids innerHTML)
   var playTemplate = document.createElement('template');

--- a/packages/core/src/dev/server.js
+++ b/packages/core/src/dev/server.js
@@ -14,9 +14,16 @@ import { execFile } from 'node:child_process'
 import { startBundlerServer } from '../renderer/render.js'
 
 /**
+ * @typedef {import('../types.js').AsyncCleanup} AsyncCleanup
+ * @typedef {import('../types.js').DevServerOptions} DevServerOptions
+ * @typedef {import('../types.js').DevServerResult} DevServerResult
+ */
+
+/**
  * Open a URL in the user's default browser using platform-native commands.
  * Uses execFile (not exec) to avoid shell injection.
  * @param {string} url
+ * @returns {void}
  */
 function openBrowser(url) {
   const cmd = process.platform === 'darwin' ? 'open'
@@ -36,10 +43,11 @@ function openBrowser(url) {
  * @param {number} options.height
  * @param {string|null} [options.serverUrl] - BYOS server URL (Nuxt/Quasar)
  * @param {'vite'|'rsbuild'} [options.bundler]
+ * @param {boolean} [options.syncConfigWithComponent]
  * @param {string|null} [options.configFile]
- * @param {string} [options.projectType]
+ * @param {import('../types.js').ProjectType} [options.projectType]
  * @param {string} [options.version] - Package version (shown in overlay)
- * @returns {Promise<void>}
+ * @returns {Promise<DevServerResult>}
  */
 export async function startDevServer(options) {
   const {
@@ -50,12 +58,14 @@ export async function startDevServer(options) {
     height = 1080,
     serverUrl = null,
     bundler = 'vite',
+    syncConfigWithComponent = false,
     configFile = null,
     projectType = 'standalone',
     version = ''
   } = options
 
   let url
+  /** @type {AsyncCleanup} */
   let cleanup
 
   if (serverUrl) {
@@ -82,7 +92,8 @@ export async function startDevServer(options) {
 
   // Build the full URL with config params
   const separator = url.includes('?') ? '&' : '?'
-  const fullUrl = `${url}${separator}fps=${fps}&duration=${durationInFrames}&width=${width}&height=${height}`
+  const configRefresh = syncConfigWithComponent ? '&config-refresh=1' : ''
+  const fullUrl = `${url}${separator}fps=${fps}&duration=${durationInFrames}&width=${width}&height=${height}&preview=1${configRefresh}`
 
   // Open in the user's default browser
   openBrowser(fullUrl)
@@ -93,8 +104,12 @@ export async function startDevServer(options) {
     process.exit(0)
   }
 
-  process.on('SIGINT', shutdown)
-  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', () => {
+    void shutdown()
+  })
+  process.on('SIGTERM', () => {
+    void shutdown()
+  })
 
   return { url: fullUrl, cleanup }
 }

--- a/packages/core/src/globals.js
+++ b/packages/core/src/globals.js
@@ -1,0 +1,21 @@
+/**
+ * Editor-only globals for Pellicule macros.
+ *
+ * This file is intentionally never imported at runtime. Keeping the macro
+ * shape in plain JavaScript lets TS-based editors understand
+ * `defineVideoConfig()` inside this workspace without introducing `.d.ts`
+ * files or changing the runtime behavior of the macro.
+ *
+ * @typedef {import('./types.js').DefineVideoConfig} DefineVideoConfig
+ */
+
+/**
+ * Compile-time Pellicule macro for video defaults.
+ *
+ * @type {DefineVideoConfig}
+ */
+function defineVideoConfig(config) {
+  return config
+}
+
+void defineVideoConfig

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -10,8 +10,10 @@ export { useFrame } from './composables/frame.js'
 export { useVideoConfig } from './composables/video-config.js'
 export { useSequence } from './composables/sequence.js'
 export { FRAME_KEY, CONFIG_KEY, SEQUENCE_KEY } from './composables/keys.js'
+export { defineVideoConfig } from './define-video-config.js'
 
 // Components
+// @ts-expect-error Vue SFCs are resolved by Vite/Rsbuild, not plain Node module resolution.
 export { default as Sequence } from './components/Sequence.vue'
 
 // Animation utilities

--- a/packages/core/src/macros/define-video-config.js
+++ b/packages/core/src/macros/define-video-config.js
@@ -14,12 +14,30 @@
 
 import { readFileSync } from 'fs'
 
+/**
+ * @typedef {import('../types.js').CliVideoConfigFlags} CliVideoConfigFlags
+ * @typedef {import('../types.js').VideoConfig} VideoConfig
+ * @typedef {import('../types.js').VideoConfigInput} VideoConfigInput
+ * @typedef {import('../types.js').VideoConfigLiteral} VideoConfigLiteral
+ */
+
+const DEFINE_VIDEO_CONFIG_RUNTIME = `((config) => {
+  if (typeof globalThis === 'undefined') return
+  globalThis.__PELLICULE_COMPONENT_CONFIG__ = config
+  if (typeof globalThis.__PELLICULE_ON_CONFIG__ === 'function') {
+    globalThis.__PELLICULE_ON_CONFIG__(config)
+  }
+})`
+
 // ============================================================================
 // Config Extraction (for CLI)
 // ============================================================================
 
 /**
  * Extract video config from a .vue file.
+ *
+ * @param {string} filePath
+ * @returns {VideoConfigLiteral | null}
  */
 export function extractVideoConfig(filePath) {
   const source = readFileSync(filePath, 'utf-8')
@@ -28,6 +46,9 @@ export function extractVideoConfig(filePath) {
 
 /**
  * Extract video config from Vue SFC source code.
+ *
+ * @param {string} source
+ * @returns {VideoConfigLiteral | null}
  */
 export function extractVideoConfigFromSource(source) {
   // Extract <script setup> content with a regex instead of pulling in
@@ -42,13 +63,17 @@ export function extractVideoConfigFromSource(source) {
   try {
     return parseObjectLiteral(match[1])
   } catch (error) {
-    console.warn(`Failed to parse defineVideoConfig: ${error.message}`)
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`Failed to parse defineVideoConfig: ${message}`)
     return null
   }
 }
 
 /**
  * Parse a static object literal string.
+ *
+ * @param {string} str
+ * @returns {VideoConfigLiteral}
  */
 function parseObjectLiteral(str) {
   const trimmed = str.trim()
@@ -56,30 +81,38 @@ function parseObjectLiteral(str) {
     throw new Error('Not an object literal')
   }
 
+  /** @type {Record<string, string | number | boolean | undefined>} */
   const config = {}
   const regex = /(\w+)\s*:\s*(-?\d+(?:\.\d+)?|true|false|'[^']*'|"[^"]*")/g
   let match
 
   while ((match = regex.exec(trimmed)) !== null) {
     const key = match[1]
-    let value = match[2]
+    const rawValue = match[2]
+    /** @type {string | number | boolean} */
+    let value
 
-    if (value === 'true') value = true
-    else if (value === 'false') value = false
-    else if (value.startsWith("'") || value.startsWith('"')) value = value.slice(1, -1)
-    else value = parseFloat(value)
+    if (rawValue === 'true') value = true
+    else if (rawValue === 'false') value = false
+    else if (rawValue.startsWith("'") || rawValue.startsWith('"')) value = rawValue.slice(1, -1)
+    else value = parseFloat(rawValue)
 
     config[key] = value
   }
 
-  return config
+  return /** @type {VideoConfigLiteral} */ (config)
 }
 
 /**
  * Resolve final config: defaults < defineVideoConfig < CLI flags
+ *
+ * @param {{ componentConfig?: VideoConfigInput | null, cliFlags?: CliVideoConfigFlags }} options
+ * @returns {VideoConfig}
  */
 export function resolveVideoConfig({ componentConfig, cliFlags }) {
+  /** @type {VideoConfig} */
   const defaults = { fps: 30, width: 1920, height: 1080, durationInFrames: 90 }
+  /** @type {VideoConfig} */
   const config = { ...defaults }
 
   if (componentConfig) {
@@ -106,10 +139,11 @@ export function resolveVideoConfig({ componentConfig, cliFlags }) {
 // ============================================================================
 
 /**
- * Strip defineVideoConfig() calls and imports from source code.
+ * Remove mistaken defineVideoConfig imports from source code.
  *
- * This is the core transform logic used by both the Vite plugin and
- * the Rsbuild plugin. It's pure string manipulation — no bundler APIs.
+ * The macro call itself is preserved and replaced at compile time via
+ * Vite/Rsbuild `define`, which lets Pellicule observe config changes
+ * during dev HMR without requiring an import.
  *
  * @param {string} code - Source code (typically a .vue file)
  * @returns {string|null} Transformed code, or null if unchanged
@@ -134,12 +168,6 @@ export function stripDefineVideoConfig(code) {
     }
   )
 
-  // Remove the defineVideoConfig() call
-  transformed = transformed.replace(
-    /defineVideoConfig\s*\(\s*\{[\s\S]*?\}\s*\)\s*;?\n?/g,
-    ''
-  )
-
   return transformed !== code ? transformed : null
 }
 
@@ -150,11 +178,21 @@ export function stripDefineVideoConfig(code) {
 /**
  * Vite plugin that strips defineVideoConfig() calls.
  * Runs before Vue's compiler (enforce: 'pre').
+ *
+ * @returns {import('vite').Plugin}
  */
 export function pelliculeMacroVitePlugin() {
   return {
     name: 'pellicule:define-video-config',
     enforce: 'pre',
+
+    config() {
+      return {
+        define: {
+          defineVideoConfig: DEFINE_VIDEO_CONFIG_RUNTIME
+        }
+      }
+    },
 
     transform(code, id) {
       if (!id.endsWith('.vue')) return null
@@ -184,6 +222,8 @@ export function pelliculeMacroVitePlugin() {
  *
  * The api.transform() is kept as a belt-and-suspenders measure —
  * if it manages to strip the call from the raw source, even better.
+ *
+ * @returns {object}
  */
 export function pelliculeMacroRsbuildPlugin() {
   return {
@@ -195,7 +235,7 @@ export function pelliculeMacroRsbuildPlugin() {
       api.modifyRsbuildConfig((config) => {
         config.source = config.source || {}
         config.source.define = config.source.define || {}
-        config.source.define.defineVideoConfig = '(function(){})'
+        config.source.define.defineVideoConfig = DEFINE_VIDEO_CONFIG_RUNTIME
       })
 
       // Also attempt to strip the call from .vue source directly.

--- a/packages/core/src/nuxt/runtime/render-page.vue
+++ b/packages/core/src/nuxt/runtime/render-page.vue
@@ -11,6 +11,8 @@
  */
 import { ref, provide, onMounted, nextTick, shallowRef } from 'vue'
 import { resolveVideoComponent, getAvailableVideos } from '#pellicule/video-components'
+import { buildVideoConfigUrl, haveVideoConfigChanged, resolveVideoConfig } from '../../runtime/config.js'
+import { waitForRenderReady } from '../../runtime/ready.js'
 
 definePageMeta({
   layout: false
@@ -24,6 +26,9 @@ const fps = parseInt(route.query.fps || '30', 10)
 const durationInFrames = parseInt(route.query.duration || '90', 10)
 const width = parseInt(route.query.width || '1920', 10)
 const height = parseInt(route.query.height || '1080', 10)
+const isPreview = route.query.preview === '1'
+const allowPreviewConfigSync = isPreview && route.query['config-refresh'] === '1'
+let pendingReload = false
 
 // ── Viewport styling ────────────────────────────────────────────────
 // Inject viewport CSS directly via DOM instead of useHead(), which
@@ -64,19 +69,54 @@ if (!componentName) {
   }
 }
 
+if (import.meta.client) {
+  window.__PELLICULE_COMPONENT_CONFIG__ = null
+  window.__PELLICULE_ON_CONFIG__ = (componentConfig) => {
+    if (!allowPreviewConfigSync || pendingReload) {
+      return
+    }
+
+    const nextConfig = resolveVideoConfig(config, componentConfig)
+    if (!haveVideoConfigChanged(config, nextConfig)) {
+      return
+    }
+
+    pendingReload = true
+    window.location.replace(buildVideoConfigUrl(window.location.href, nextConfig))
+  }
+}
+
 // ── Expose globals for Playwright ───────────────────────────────────
 onMounted(() => {
   window.__PELLICULE_SET_FRAME__ = async (frame) => {
     frameRef.value = frame
     await nextTick()
+    await waitForRenderReady()
   }
 
   if (error.value) {
     window.__PELLICULE_ERROR__ = error.value
     console.error('Pellicule render error:', error.value)
+    window.__PELLICULE_READY__ = true
+    return
   }
 
-  window.__PELLICULE_READY__ = true
+  if (pendingReload) {
+    return
+  }
+
+  waitForRenderReady()
+    .then(() => {
+      if (pendingReload) {
+        return
+      }
+      window.__PELLICULE_READY__ = true
+    })
+    .catch((err) => {
+      window.__PELLICULE_ERROR__ = err.message
+      console.error('Pellicule render error:', err)
+      window.__PELLICULE_READY__ = true
+    })
 })
 </script>
 

--- a/packages/core/src/quasar/index.js
+++ b/packages/core/src/quasar/index.js
@@ -88,12 +88,19 @@ function generateRenderPage({ component, fps, duration, width, height }) {
     import { createApp, ref, nextTick, provide, h } from 'vue'
     import { Quasar } from 'quasar'
     import 'quasar/dist/quasar.css'
+    import { buildVideoConfigUrl, haveVideoConfigChanged, parseVideoConfigFromSearch, resolveVideoConfig } from 'pellicule/runtime/config'
+    import { waitForRenderReady } from 'pellicule/runtime/ready'
 
     const componentName = ${safeComponent}
-    const fps = ${parseInt(fps)}
-    const duration = ${parseInt(duration)}
-    const width = ${parseInt(width)}
-    const height = ${parseInt(height)}
+    const params = new URLSearchParams(window.location.search)
+    const isPreview = params.get('preview') === '1'
+    const allowPreviewConfigSync = isPreview && params.get('config-refresh') === '1'
+    const config = parseVideoConfigFromSearch(window.location.search, {
+      fps: ${parseInt(fps)},
+      durationInFrames: ${parseInt(duration)},
+      width: ${parseInt(width)},
+      height: ${parseInt(height)}
+    })
 
     if (!componentName) {
       window.__PELLICULE_ERROR__ = 'Missing ?component= query parameter'
@@ -104,7 +111,22 @@ function generateRenderPage({ component, fps, duration, width, height }) {
         const VideoComponent = mod.default
 
         const frameRef = ref(0)
-        const config = { fps, durationInFrames: duration, width, height }
+        let pendingReload = false
+
+        window.__PELLICULE_COMPONENT_CONFIG__ = null
+        window.__PELLICULE_ON_CONFIG__ = (componentConfig) => {
+          if (!allowPreviewConfigSync || pendingReload) {
+            return
+          }
+
+          const nextConfig = resolveVideoConfig(config, componentConfig)
+          if (!haveVideoConfigChanged(config, nextConfig)) {
+            return
+          }
+
+          pendingReload = true
+          window.location.replace(buildVideoConfigUrl(window.location.href, nextConfig))
+        }
 
         const app = createApp({
           setup() {
@@ -117,11 +139,17 @@ function generateRenderPage({ component, fps, duration, width, height }) {
         app.use(Quasar, {})
         app.mount('#pellicule-app')
 
-        window.__PELLICULE_SET_FRAME__ = async (frame) => {
-          frameRef.value = frame
+        if (!pendingReload) {
+          window.__PELLICULE_SET_FRAME__ = async (frame) => {
+            frameRef.value = frame
+            await nextTick()
+            await waitForRenderReady()
+          }
+
           await nextTick()
+          await waitForRenderReady()
+          window.__PELLICULE_READY__ = true
         }
-        window.__PELLICULE_READY__ = true
       } catch (err) {
         window.__PELLICULE_ERROR__ = err.message
         console.error('Pellicule render error:', err)

--- a/packages/core/src/renderer/encode.js
+++ b/packages/core/src/renderer/encode.js
@@ -2,14 +2,15 @@ import { spawn } from 'child_process'
 import path from 'path'
 
 /**
+ * @typedef {import('../types.js').EncodeVideoOptions} EncodeVideoOptions
+ * @typedef {import('../types.js').RenderToMp4Options} RenderToMp4Options
+ * @typedef {import('../types.js').RenderVideoOptions} RenderVideoOptions
+ */
+
+/**
  * Encodes PNG frames into an MP4 video using FFmpeg.
  *
- * @param {object} options
- * @param {string} options.framesDir - Directory containing frame-XXXXX.png files
- * @param {string} options.output - Output video path (default: './output.mp4')
- * @param {number} options.fps - Frames per second (default: 30)
- * @param {string|null} options.audio - Audio file path to include (default: null)
- * @param {boolean} options.silent - Suppress console output (default: false)
+ * @param {EncodeVideoOptions} options
  * @returns {Promise<string>} Path to the output video
  */
 export function encodeVideo(options) {
@@ -75,19 +76,15 @@ export function encodeVideo(options) {
 /**
  * Full render pipeline: Vue component → frames → MP4
  *
- * @param {object} options - Same as renderVideo, plus output path
- * @param {string|null} options.audio - Audio file path to include (default: null)
- * @param {boolean} options.silent - Suppress console output (default: false)
- * @param {string|null} [options.serverUrl] - BYOS: skip bundler, use this URL
- * @param {'vite'|'rsbuild'} [options.bundler] - Which bundler adapter to use
- * @param {string|null} [options.configFile] - Path to the user's config file
- * @param {string} [options.projectType] - Detected project type
+ * @param {RenderToMp4Options} options - Same as renderVideo, plus output path
  * @returns {Promise<string>} Path to the output video
  */
 export async function renderToMp4(options) {
   const { renderVideo } = await import('./render.js')
 
-  const { output = './output.mp4', audio = null, silent = false, ...renderOptions } = options
+  const { output = './output.mp4', audio = null, silent = false, ...rawRenderOptions } = options
+  /** @type {RenderVideoOptions} */
+  const renderOptions = rawRenderOptions
 
   // Step 1: Render frames (stored in .pellicule/frames)
   const { framesDir, cleanup } = await renderVideo({ ...renderOptions, silent })

--- a/packages/core/src/renderer/render.js
+++ b/packages/core/src/renderer/render.js
@@ -2,21 +2,18 @@ import { chromium } from 'playwright'
 import { mkdir, rm } from 'fs/promises'
 import { join, dirname } from 'path'
 
+/** @typedef {import('../types.js').PelliculeWindow} PelliculeWindow */
+/** @typedef {import('../types.js').BundlerServerOptions} BundlerServerOptions */
+/** @typedef {import('../types.js').BundlerServerResult} BundlerServerResult */
+/** @typedef {import('../types.js').ProgressCallback} ProgressCallback */
+/** @typedef {import('../types.js').RenderVideoOptions} RenderVideoOptions */
+/** @typedef {import('../types.js').RenderVideoResult} RenderVideoResult */
+
 /**
  * Create a video server using the appropriate bundler adapter.
  *
- * @param {object} options
- * @param {string} options.input - Absolute path to the .vue file
- * @param {number} options.width
- * @param {number} options.height
- * @param {'vite'|'rsbuild'} options.bundler - Which bundler adapter to use
- * @param {string|null} options.configFile - Path to the user's config file
- * @param {string} options.projectType - Detected project type (for Shipwright config reading)
- * @param {boolean} [options.preview] - Whether to inject the dev preview overlay
- * @param {number} [options.fps] - FPS (passed to overlay when preview=true)
- * @param {number} [options.durationInFrames] - Total frames (passed to overlay when preview=true)
- * @param {string} [options.version] - Package version (shown in overlay)
- * @returns {Promise<{ url: string, cleanup: function, tempDir: string }>}
+ * @param {BundlerServerOptions} options
+ * @returns {Promise<BundlerServerResult>}
  */
 export async function startBundlerServer(options) {
   const { bundler = 'vite', ...serverOptions } = options
@@ -35,20 +32,8 @@ export async function startBundlerServer(options) {
 /**
  * Renders a .vue component to video frames.
  *
- * @param {object} options
- * @param {string} options.input - Path to the .vue file
- * @param {number} options.fps - Frames per second (default: 30)
- * @param {number} options.durationInFrames - Total frames in the video (for animation calculations)
- * @param {number} options.startFrame - First frame to render (default: 0)
- * @param {number} options.endFrame - Last frame to render, exclusive (default: durationInFrames)
- * @param {number} options.width - Video width in pixels (default: 1920)
- * @param {number} options.height - Video height in pixels (default: 1080)
- * @param {function} options.onProgress - Progress callback
- * @param {string|null} [options.serverUrl] - BYOS: skip bundler, use this URL instead
- * @param {'vite'|'rsbuild'} [options.bundler] - Which bundler adapter to use (default: 'vite')
- * @param {string|null} [options.configFile] - Path to the user's config file
- * @param {string} [options.projectType] - Detected project type
- * @returns {Promise<{ framesDir: string, totalFrames: number, cleanup: function }>}
+ * @param {RenderVideoOptions} options
+ * @returns {Promise<RenderVideoResult>}
  */
 export async function renderVideo(options) {
   const {
@@ -147,10 +132,10 @@ export async function renderVideo(options) {
     await page.goto(pageUrl, { waitUntil: 'networkidle' })
 
     // Wait for Vue to mount
-    await page.waitForFunction(() => window.__PELLICULE_READY__ === true, { timeout: 10000 })
+    await page.waitForFunction(() => /** @type {PelliculeWindow} */ (window).__PELLICULE_READY__ === true, { timeout: 10000 })
 
     // Check for errors
-    const error = await page.evaluate(() => window.__PELLICULE_ERROR__)
+    const error = await page.evaluate(() => /** @type {PelliculeWindow} */ (window).__PELLICULE_ERROR__)
     if (error) {
       throw new Error(`Render error: ${error}`)
     }
@@ -160,7 +145,7 @@ export async function renderVideo(options) {
     // Render each frame in the specified range
     for (let frame = startFrame; frame < actualEndFrame; frame++) {
       // Update frame number - Vue reactivity handles re-render
-      await page.evaluate((f) => window.__PELLICULE_SET_FRAME__(f), frame)
+      await page.evaluate((f) => /** @type {PelliculeWindow} */ (window).__PELLICULE_SET_FRAME__?.(f), frame)
 
       // Screenshot - output frames are numbered from 0
       const outputFrameNum = frame - startFrame

--- a/packages/core/src/runtime/config.js
+++ b/packages/core/src/runtime/config.js
@@ -1,0 +1,126 @@
+/**
+ * @typedef {import('../types.js').VideoConfig} VideoConfig
+ * @typedef {import('../types.js').VideoConfigInput} VideoConfigInput
+ * @typedef {import('../types.js').VideoConfigOverrides} VideoConfigOverrides
+ */
+
+/** @type {Readonly<VideoConfig>} */
+const DEFAULT_VIDEO_CONFIG = Object.freeze({
+  fps: 30,
+  durationInFrames: 90,
+  width: 1920,
+  height: 1080
+})
+
+/**
+ * @param {unknown} value
+ * @returns {number|null}
+ */
+function parsePositiveInteger(value) {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+
+  const parsed = Number.parseInt(String(value), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number|null}
+ */
+function parsePositiveNumber(value) {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+/**
+ * Resolve a full runtime-safe video config from defaults plus loose overrides.
+ *
+ * @param {VideoConfig} [baseConfig=DEFAULT_VIDEO_CONFIG]
+ * @param {VideoConfigInput | VideoConfigOverrides} [overrides={}]
+ * @returns {VideoConfig}
+ */
+export function resolveVideoConfig(baseConfig = DEFAULT_VIDEO_CONFIG, overrides = {}) {
+  /** @type {VideoConfig} */
+  const resolved = {
+    ...DEFAULT_VIDEO_CONFIG,
+    ...baseConfig
+  }
+
+  const fps = parsePositiveInteger(overrides.fps)
+  if (fps !== null) {
+    resolved.fps = fps
+  }
+
+  const width = parsePositiveInteger(overrides.width)
+  if (width !== null) {
+    resolved.width = width
+  }
+
+  const height = parsePositiveInteger(overrides.height)
+  if (height !== null) {
+    resolved.height = height
+  }
+
+  const durationInFrames = parsePositiveInteger(overrides.durationInFrames)
+  if (durationInFrames !== null) {
+    resolved.durationInFrames = durationInFrames
+  } else {
+    const durationInSeconds = parsePositiveNumber(overrides.durationInSeconds)
+    if (durationInSeconds !== null) {
+      resolved.durationInFrames = Math.round(durationInSeconds * resolved.fps)
+    }
+  }
+
+  return resolved
+}
+
+/**
+ * Parse Pellicule's URL query params into a normalized runtime config.
+ *
+ * @param {string} search
+ * @param {VideoConfig} [defaults=DEFAULT_VIDEO_CONFIG]
+ * @returns {VideoConfig}
+ */
+export function parseVideoConfigFromSearch(search, defaults = DEFAULT_VIDEO_CONFIG) {
+  const params = new URLSearchParams(search)
+  return resolveVideoConfig(defaults, {
+    fps: params.get('fps'),
+    durationInFrames: params.get('duration'),
+    width: params.get('width'),
+    height: params.get('height')
+  })
+}
+
+/**
+ * @param {VideoConfig} currentConfig
+ * @param {VideoConfig} nextConfig
+ * @returns {boolean}
+ */
+export function haveVideoConfigChanged(currentConfig, nextConfig) {
+  return (
+    currentConfig.fps !== nextConfig.fps ||
+    currentConfig.durationInFrames !== nextConfig.durationInFrames ||
+    currentConfig.width !== nextConfig.width ||
+    currentConfig.height !== nextConfig.height
+  )
+}
+
+/**
+ * @param {string} href
+ * @param {VideoConfig} config
+ * @returns {string}
+ */
+export function buildVideoConfigUrl(href, config) {
+  const url = new URL(href, 'http://localhost')
+  url.searchParams.set('fps', String(config.fps))
+  url.searchParams.set('duration', String(config.durationInFrames))
+  url.searchParams.set('width', String(config.width))
+  url.searchParams.set('height', String(config.height))
+  return url.toString()
+}

--- a/packages/core/src/runtime/ready.js
+++ b/packages/core/src/runtime/ready.js
@@ -1,0 +1,130 @@
+/** @typedef {import('../types.js').RenderReadyImageLike} RenderReadyImageLike */
+/** @typedef {import('../types.js').RenderReadyOptions} RenderReadyOptions */
+
+/**
+ * Wait for the next paint so layout, images, and font changes are visible.
+ *
+ * @param {(callback: (timestamp: number) => void) => any} requestAnimationFrameRef
+ * @returns {Promise<void>}
+ */
+function requestPaint(requestAnimationFrameRef) {
+  return new Promise((resolve) => {
+    requestAnimationFrameRef(() => resolve())
+  })
+}
+
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {string} label
+ * @param {number} timeoutMs
+ * @returns {Promise<T>}
+ */
+function withTimeout(promise, label, timeoutMs) {
+  let timeoutId
+
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timeoutId))
+}
+
+/**
+ * @param {RenderReadyImageLike} image
+ * @returns {string}
+ */
+function describeImage(image) {
+  return image?.currentSrc || image?.src || image?.alt || '[image]'
+}
+
+/**
+ * @param {RenderReadyImageLike} image
+ * @returns {Promise<void>}
+ */
+async function decodeImage(image) {
+  if (typeof image.decode !== 'function') {
+    return
+  }
+
+  try {
+    await image.decode()
+  } catch (error) {
+    if (!(image.complete && image.naturalWidth > 0)) {
+      throw error
+    }
+  }
+}
+
+/**
+ * @param {RenderReadyImageLike} image
+ * @returns {Promise<void>}
+ */
+async function waitForImage(image) {
+  if (image.complete) {
+    if (image.naturalWidth === 0) {
+      throw new Error(`Image failed to load: ${describeImage(image)}`)
+    }
+
+    await decodeImage(image)
+    return
+  }
+
+  await new Promise((resolve, reject) => {
+    const cleanup = () => {
+      image.removeEventListener('load', onLoad)
+      image.removeEventListener('error', onError)
+    }
+
+    const onLoad = () => {
+      cleanup()
+      resolve()
+    }
+
+    const onError = () => {
+      cleanup()
+      reject(new Error(`Image failed to load: ${describeImage(image)}`))
+    }
+
+    image.addEventListener('load', onLoad)
+    image.addEventListener('error', onError)
+  })
+
+  if (image.naturalWidth === 0) {
+    throw new Error(`Image failed to load: ${describeImage(image)}`)
+  }
+
+  await decodeImage(image)
+}
+
+/**
+ * Wait until fonts, current DOM images, and two paints have completed.
+ *
+ * This makes first-frame capture more deterministic for preview and render
+ * modes without requiring apps to manually coordinate font and image loading.
+ *
+ * @param {RenderReadyOptions} [options={}]
+ * @returns {Promise<void>}
+ */
+export async function waitForRenderReady(options = {}) {
+  const {
+    documentRef = globalThis.document,
+    requestAnimationFrameRef = globalThis.requestAnimationFrame?.bind(globalThis) ||
+      ((callback) => setTimeout(() => callback(Date.now()), 16)),
+    timeoutMs = 10000
+  } = options
+
+  await withTimeout((async () => {
+    if (documentRef?.fonts?.ready) {
+      await documentRef.fonts.ready
+    }
+
+    const images = Array.from(documentRef?.images || [])
+    await Promise.all(images.map(waitForImage))
+
+    await requestPaint(requestAnimationFrameRef)
+    await requestPaint(requestAnimationFrameRef)
+  })(), 'Render readiness', timeoutMs)
+}

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -1,0 +1,192 @@
+/**
+ * Shared JSDoc typedefs for Pellicule.
+ *
+ * These keep editor autocomplete and JS diagnostics useful without turning the
+ * package into a TypeScript codebase. The public shapes stay intentionally
+ * small and ergonomic so they work well both inside Pellicule and in apps that
+ * consume it from JavaScript.
+ *
+ * @typedef {'vite'|'rsbuild'} BundlerName
+ *
+ * @typedef {'laravel'|'vite'|'rsbuild'|'shipwright'|'nuxt'|'quasar'|'standalone'} ProjectType
+ *
+ * @typedef {Object} VideoConfig
+ * @property {number} fps
+ * @property {number} durationInFrames
+ * @property {number} width
+ * @property {number} height
+ *
+ * @typedef {Object} VideoConfigInput
+ * @property {number} [fps]
+ * @property {number} [durationInFrames]
+ * @property {number} [durationInSeconds]
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {string} [audio]
+ *
+ * @typedef {Object} VideoConfigOverrides
+ * @property {number|string|null} [fps]
+ * @property {number|string|null} [durationInFrames]
+ * @property {number|string|null} [durationInSeconds]
+ * @property {number|string|null} [width]
+ * @property {number|string|null} [height]
+ * @property {string|null} [audio]
+ *
+ * @typedef {VideoConfigInput & Record<string, string|number|boolean|undefined>} VideoConfigLiteral
+ *
+ * @typedef {Object} CliVideoConfigFlags
+ * @property {number} [duration]
+ * @property {number} [fps]
+ * @property {number} [width]
+ * @property {number} [height]
+ *
+ * @typedef {(t: number) => number} EasingFunction
+ *
+ * @typedef {Object} InterpolationOptions
+ * @property {EasingFunction} [easing]
+ * @property {'clamp'|'extend'} [extrapolate]
+ *
+ * @typedef {Object} SequenceStep
+ * @property {number} start
+ * @property {number} end
+ * @property {number} from
+ * @property {number} to
+ *
+ * @typedef {Object} SequenceContext
+ * @property {import('vue').ComputedRef<number>} localFrame
+ * @property {import('vue').ComputedRef<number>} progress
+ * @property {import('vue').ComputedRef<boolean>} isActive
+ *
+ * @typedef {SequenceContext & {
+ *   from: number,
+ *   durationInFrames: number
+ * }} SequenceProviderContext
+ *
+ * @typedef {(config: VideoConfigInput) => void} ComponentConfigHandler
+ *
+ * @typedef {Window & typeof globalThis & {
+ *   __PELLICULE_SET_FRAME__?: (frame: number) => Promise<void>,
+ *   __PELLICULE_READY__?: boolean,
+ *   __PELLICULE_ERROR__?: string,
+ *   __PELLICULE_COMPONENT_CONFIG__?: VideoConfigInput | null,
+ *   __PELLICULE_ON_CONFIG__?: ComponentConfigHandler | null
+ * }} PelliculeWindow
+ *
+ * @typedef {Object} RenderReadyImageLike
+ * @property {string} [alt]
+ * @property {string} [src]
+ * @property {string} [currentSrc]
+ * @property {boolean} complete
+ * @property {number} naturalWidth
+ * @property {(() => Promise<void>)} [decode]
+ * @property {(type: string, listener: () => void) => void} addEventListener
+ * @property {(type: string, listener?: () => void) => void} removeEventListener
+ *
+ * @typedef {Object} RenderReadyDocumentLike
+ * @property {{ ready: Promise<unknown> }} [fonts]
+ * @property {ArrayLike<RenderReadyImageLike>} [images]
+ *
+ * @typedef {Object} RenderReadyOptions
+ * @property {RenderReadyDocumentLike} [documentRef]
+ * @property {(callback: (timestamp: number) => void) => any} [requestAnimationFrameRef]
+ * @property {number} [timeoutMs]
+ *
+ * @typedef {Object} PelliculeProjectConfig
+ * @property {string} [serverUrl]
+ * @property {string} [videosDir]
+ * @property {string} [outDir]
+ * @property {BundlerName} [bundler]
+ *
+ * @typedef {Object} DetectedProject
+ * @property {ProjectType} projectType
+ * @property {BundlerName} bundler
+ * @property {string|null} configFile
+ * @property {string} videosDir
+ * @property {boolean} byos
+ * @property {string|null} [defaultServerUrl]
+ *
+ * @typedef {{ resolved: string }} InputResolutionSuccess
+ * @typedef {{ error: string, searched: string[] }} InputResolutionFailure
+ * @typedef {InputResolutionSuccess | InputResolutionFailure} InputResolutionResult
+ *
+ * @typedef {() => Promise<void>} AsyncCleanup
+ *
+ * @typedef {Object} BundlerServerResult
+ * @property {object} server
+ * @property {string} url
+ * @property {AsyncCleanup} cleanup
+ * @property {string} tempDir
+ *
+ * @typedef {Object} BundlerServerOptions
+ * @property {string} input
+ * @property {number} width
+ * @property {number} height
+ * @property {BundlerName} [bundler]
+ * @property {string|null} [configFile]
+ * @property {ProjectType} [projectType]
+ * @property {boolean} [preview]
+ * @property {number} [fps]
+ * @property {number} [durationInFrames]
+ * @property {string} [version]
+ *
+ * @typedef {Object} DevServerOptions
+ * @property {string} input
+ * @property {number} [fps]
+ * @property {number} [durationInFrames]
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {string|null} [serverUrl]
+ * @property {BundlerName} [bundler]
+ * @property {boolean} [syncConfigWithComponent]
+ * @property {string|null} [configFile]
+ * @property {ProjectType} [projectType]
+ * @property {string} [version]
+ *
+ * @typedef {Object} DevServerResult
+ * @property {string} url
+ * @property {AsyncCleanup} cleanup
+ *
+ * @typedef {Object} RenderProgress
+ * @property {number} frame
+ * @property {number} total
+ * @property {number} fps
+ *
+ * @typedef {(progress: RenderProgress) => void} ProgressCallback
+ *
+ * @typedef {Object} RenderVideoOptions
+ * @property {string} input
+ * @property {number} fps
+ * @property {number} durationInFrames
+ * @property {number} [startFrame]
+ * @property {number} [endFrame]
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {ProgressCallback} [onProgress]
+ * @property {boolean} [silent]
+ * @property {string|null} [serverUrl]
+ * @property {BundlerName} [bundler]
+ * @property {string|null} [configFile]
+ * @property {ProjectType} [projectType]
+ *
+ * @typedef {Object} RenderVideoResult
+ * @property {string} framesDir
+ * @property {number} totalFrames
+ * @property {AsyncCleanup} cleanup
+ *
+ * @typedef {Object} EncodeVideoOptions
+ * @property {string} framesDir
+ * @property {string} [output]
+ * @property {number} [fps]
+ * @property {string|null} [audio]
+ * @property {boolean} [silent]
+ *
+ * @typedef {RenderVideoOptions & {
+ *   output?: string,
+ *   audio?: string|null,
+ *   silent?: boolean
+ * }} RenderToMp4Options
+ *
+ * @typedef {(config: VideoConfigInput) => VideoConfigInput} DefineVideoConfig
+ */
+
+export {}

--- a/packages/core/src/utils/math.js
+++ b/packages/core/src/utils/math.js
@@ -1,6 +1,13 @@
 /**
+ * @typedef {import('../types.js').EasingFunction} EasingFunction
+ * @typedef {import('../types.js').InterpolationOptions} InterpolationOptions
+ * @typedef {import('../types.js').SequenceStep} SequenceStep
+ */
+
+/**
  * Easing functions for smooth animations
  */
+/** @type {{ linear: EasingFunction, easeIn: EasingFunction, easeOut: EasingFunction, easeInOut: EasingFunction }} */
 export const Easing = {
   linear: (t) => t,
   easeIn: (t) => t * t,
@@ -15,9 +22,7 @@ export const Easing = {
  * @param {number} frame - Current frame number
  * @param {[number, number]} inputRange - [startFrame, endFrame]
  * @param {[number, number]} outputRange - [startValue, endValue]
- * @param {object} options - Optional settings
- * @param {function} options.easing - Easing function (default: linear)
- * @param {'clamp'|'extend'} options.extrapolate - Behavior outside input range
+ * @param {InterpolationOptions} [options] - Optional settings
  * @returns {number} Interpolated value
  *
  * @example
@@ -54,7 +59,7 @@ export function interpolate(frame, inputRange, outputRange, options = {}) {
  * Useful for staggered or chained animations.
  *
  * @param {number} frame - Current frame number
- * @param {Array<{start: number, end: number, from: number, to: number}>} sequence
+ * @param {SequenceStep[]} steps
  * @returns {number} Current value in the sequence
  *
  * @example

--- a/packages/core/test/runtime.test.js
+++ b/packages/core/test/runtime.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildVideoConfigUrl,
+  haveVideoConfigChanged,
+  parseVideoConfigFromSearch,
+  resolveVideoConfig
+} from '../src/runtime/config.js'
+import { waitForRenderReady } from '../src/runtime/ready.js'
+
+function createMockImage(options = {}) {
+  const listeners = new Map()
+  const image = {
+    alt: options.alt || '',
+    src: options.src || '',
+    currentSrc: options.currentSrc || options.src || '',
+    complete: options.complete ?? true,
+    naturalWidth: options.naturalWidth ?? 100,
+    decode: options.decode || null,
+    addEventListener(type, listener) {
+      listeners.set(type, listener)
+    },
+    removeEventListener(type) {
+      listeners.delete(type)
+    },
+    emit(type) {
+      const listener = listeners.get(type)
+      if (listener) {
+        listener()
+      }
+    }
+  }
+
+  return image
+}
+
+test('resolveVideoConfig derives duration from durationInSeconds using the resolved fps', () => {
+  const config = resolveVideoConfig(
+    { fps: 30, durationInFrames: 90, width: 1920, height: 1080 },
+    { fps: 60, durationInSeconds: 2.5 }
+  )
+
+  assert.deepEqual(config, {
+    fps: 60,
+    durationInFrames: 150,
+    width: 1920,
+    height: 1080
+  })
+})
+
+test('parseVideoConfigFromSearch reads query params with sane fallbacks', () => {
+  const config = parseVideoConfigFromSearch('?fps=48&duration=240&width=1280', {
+    fps: 30,
+    durationInFrames: 90,
+    width: 1920,
+    height: 1080
+  })
+
+  assert.deepEqual(config, {
+    fps: 48,
+    durationInFrames: 240,
+    width: 1280,
+    height: 1080
+  })
+})
+
+test('buildVideoConfigUrl preserves unrelated query params while replacing config values', () => {
+  const url = buildVideoConfigUrl('http://localhost:4173/pellicule?component=Demo&preview=1', {
+    fps: 60,
+    durationInFrames: 180,
+    width: 1080,
+    height: 1920
+  })
+
+  assert.equal(
+    url,
+    'http://localhost:4173/pellicule?component=Demo&preview=1&fps=60&duration=180&width=1080&height=1920'
+  )
+})
+
+test('haveVideoConfigChanged detects runtime config mismatches', () => {
+  const currentConfig = { fps: 30, durationInFrames: 90, width: 1920, height: 1080 }
+  const sameConfig = { ...currentConfig }
+  const nextConfig = { ...currentConfig, durationInFrames: 120 }
+
+  assert.equal(haveVideoConfigChanged(currentConfig, sameConfig), false)
+  assert.equal(haveVideoConfigChanged(currentConfig, nextConfig), true)
+})
+
+test('waitForRenderReady resolves after fonts and images are ready', async () => {
+  let rafCalls = 0
+  const image = createMockImage({
+    decode: async () => {}
+  })
+
+  await waitForRenderReady({
+    documentRef: {
+      fonts: { ready: Promise.resolve() },
+      images: [image]
+    },
+    requestAnimationFrameRef(callback) {
+      rafCalls += 1
+      callback(0)
+    },
+    timeoutMs: 50
+  })
+
+  assert.equal(rafCalls, 2)
+})
+
+test('waitForRenderReady waits for late-loading images', async () => {
+  const image = createMockImage({
+    complete: false,
+    naturalWidth: 0,
+    src: 'https://example.com/poster.png'
+  })
+
+  const ready = waitForRenderReady({
+    documentRef: {
+      fonts: { ready: Promise.resolve() },
+      images: [image]
+    },
+    requestAnimationFrameRef(callback) {
+      callback(0)
+    },
+    timeoutMs: 100
+  })
+
+  setTimeout(() => {
+    image.complete = true
+    image.naturalWidth = 400
+    image.emit('load')
+  }, 10)
+
+  await ready
+})
+
+test('waitForRenderReady rejects on broken images', async () => {
+  const image = createMockImage({
+    naturalWidth: 0,
+    src: 'https://example.com/broken.png'
+  })
+
+  await assert.rejects(
+    waitForRenderReady({
+      documentRef: {
+        fonts: { ready: Promise.resolve() },
+        images: [image]
+      },
+      requestAnimationFrameRef(callback) {
+        callback(0)
+      },
+      timeoutMs: 50
+    }),
+    /Image failed to load: https:\/\/example.com\/broken.png/
+  )
+})


### PR DESCRIPTION
## What changed
- wait for fonts and DOM images before frame capture, and re-check readiness after frame changes across the Vite, Nuxt, and Quasar entry paths
- keep `pellicule dev` in sync when `defineVideoConfig()` changes by refreshing preview URL config and overlay state automatically
- improve JS editor support with `jsconfig`, shared typedefs, stronger JSDoc, and an optional `defineVideoConfig` import path for external apps
- update the `examples/skills` demo and README so the manual verification path exercises the new preview and readiness behavior

## Why
Pellicule was marking renders ready too early, which could race fonts and images on the first captured frames. Dev preview could also keep stale duration and sizing values in the URL after `defineVideoConfig()` changed. While fixing that foundation, we also tightened the JS typing story so TS-powered editors can provide better completions and diagnostics in Pellicule projects.

## Impact
- renders are more deterministic on first paint
- preview stays aligned with component-driven config changes
- JS/TS editors provide better autocomplete, hover docs, and diagnostics
- the skills demo gives us a stronger real-world smoke path for preview and render behavior

## Validation
- `npm test`
- `npm run typecheck`
- manual `examples/skills` preview verification
- manual `examples/skills` render verification

Closes #27
Fixes #27
Resolves #27
