### PR TITLE
Replace brittle defineVideoConfig parsing with a structured parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -36,7 +35,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -46,7 +44,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
       "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.6"
       },
@@ -62,7 +59,6 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
       "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -879,7 +875,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
       "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/shared": "3.5.27",
@@ -893,7 +888,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
       "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.27",
         "@vue/shared": "3.5.27"
@@ -904,7 +898,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
       "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.27",
@@ -922,7 +915,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
       "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/shared": "3.5.27"
@@ -980,8 +972,7 @@
       "version": "3.5.27",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
       "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1111,7 +1102,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -1168,8 +1158,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -1798,7 +1787,9 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@babel/parser": "^7.28.5",
         "@vitejs/plugin-vue": "^5.0.0",
+        "@vue/compiler-sfc": "^3.5.27",
         "playwright": "^1.40.0",
         "vite": "^5.0.0"
       },

--- a/packages/core/bin/cli.js
+++ b/packages/core/bin/cli.js
@@ -5,7 +5,7 @@ import { resolve, join, extname, basename, dirname } from 'node:path'
 import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { renderToMp4 } from '../src/render.js'
-import { extractVideoConfig, resolveVideoConfig } from '../src/macros/define-video-config.js'
+import { DefineVideoConfigParseError, extractVideoConfig, resolveVideoConfig } from '../src/macros/define-video-config.js'
 import { detectProject, readPelliculeConfig, resolveInputFile } from '../src/config/detect.js'
 import { startDevServer } from '../src/dev/server.js'
 
@@ -296,7 +296,15 @@ async function main() {
   }
 
   // Extract config from component (if defineVideoConfig is used)
-  const componentConfig = extractVideoConfig(inputPath)
+  let componentConfig
+  try {
+    componentConfig = extractVideoConfig(inputPath)
+  } catch (error) {
+    if (error instanceof DefineVideoConfigParseError) {
+      fail(error.message, 'Keep defineVideoConfig() to one static object literal.')
+    }
+    throw error
+  }
 
   // Resolve audio file path (CLI flag takes precedence over component config)
   /** @type {string | null} */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,8 @@
     "url": "https://github.com/sailscastshq/pellicule"
   },
   "dependencies": {
+    "@babel/parser": "^7.28.5",
+    "@vue/compiler-sfc": "^3.5.27",
     "@vitejs/plugin-vue": "^5.0.0",
     "playwright": "^1.40.0",
     "vite": "^5.0.0"

--- a/packages/core/src/macros/define-video-config.js
+++ b/packages/core/src/macros/define-video-config.js
@@ -13,12 +13,17 @@
  */
 
 import { readFileSync } from 'fs'
+import { parse as parseScript } from '@babel/parser'
+import { parse as parseSfc } from '@vue/compiler-sfc'
 
 /**
  * @typedef {import('../types.js').CliVideoConfigFlags} CliVideoConfigFlags
  * @typedef {import('../types.js').VideoConfig} VideoConfig
  * @typedef {import('../types.js').VideoConfigInput} VideoConfigInput
  * @typedef {import('../types.js').VideoConfigLiteral} VideoConfigLiteral
+ * @typedef {string|number|boolean|null} StaticConfigPrimitive
+ * @typedef {StaticConfigPrimitive | Record<string, unknown> | unknown[]} StaticConfigValue
+ * @typedef {Record<string, unknown>} StaticConfigObject
  */
 
 const DEFINE_VIDEO_CONFIG_RUNTIME = `((config) => {
@@ -33,6 +38,320 @@ const DEFINE_VIDEO_CONFIG_RUNTIME = `((config) => {
 // Config Extraction (for CLI)
 // ============================================================================
 
+export class DefineVideoConfigParseError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ filename?: string, line?: number|null, column?: number|null, hint?: string }} [options]
+   */
+  constructor(message, options = {}) {
+    const { filename, line = null, column = null, hint } = options
+    const location = filename && line !== null && column !== null
+      ? `${filename}:${line}:${column}`
+      : filename || null
+    const suffix = hint ? ` Hint: ${hint}` : ''
+    super(location ? `${location} ${message}${suffix}` : `${message}${suffix}`)
+    this.name = 'DefineVideoConfigParseError'
+  }
+}
+
+/**
+ * @param {string} source
+ * @param {number} offset
+ * @returns {{ line: number, column: number }}
+ */
+function offsetToLineColumn(source, offset) {
+  const safeOffset = Math.max(0, Math.min(offset, source.length))
+  let line = 1
+  let lastLineStart = 0
+
+  for (let index = 0; index < safeOffset; index++) {
+    if (source[index] === '\n') {
+      line += 1
+      lastLineStart = index + 1
+    }
+  }
+
+  return {
+    line,
+    column: safeOffset - lastLineStart + 1
+  }
+}
+
+/**
+ * @param {{ filename: string, source: string, contentStartOffset: number }} context
+ * @param {string} message
+ * @param {{ start?: number|null } | undefined} node
+ * @param {string} [hint]
+ * @returns {DefineVideoConfigParseError}
+ */
+function createParseError(context, message, node, hint) {
+  const relativeOffset = typeof node?.start === 'number' ? node.start : 0
+  const { line, column } = offsetToLineColumn(context.source, context.contentStartOffset + relativeOffset)
+  return new DefineVideoConfigParseError(message, {
+    filename: context.filename,
+    line,
+    column,
+    hint
+  })
+}
+
+/**
+ * @param {string|null|undefined} lang
+ * @returns {import('@babel/parser').ParserPlugin[]}
+ */
+function getScriptParserPlugins(lang) {
+  /** @type {import('@babel/parser').ParserPlugin[]} */
+  const plugins = ['importAttributes']
+
+  if (lang === 'ts' || lang === 'tsx') {
+    plugins.push('typescript')
+  }
+
+  if (lang === 'jsx' || lang === 'tsx') {
+    plugins.push('jsx')
+  }
+
+  return plugins
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, any>}
+ */
+function isAstNode(value) {
+  return !!value && typeof value === 'object' && typeof /** @type {{ type?: unknown }} */ (value).type === 'string'
+}
+
+/**
+ * @param {unknown} expression
+ * @returns {expression is Record<string, any>}
+ */
+function isDefineVideoConfigCall(expression) {
+  return isAstNode(expression)
+    && expression.type === 'CallExpression'
+    && isAstNode(expression.callee)
+    && expression.callee.type === 'Identifier'
+    && expression.callee.name === 'defineVideoConfig'
+    && Array.isArray(expression.arguments)
+}
+
+/**
+ * @param {unknown} expression
+ * @returns {Record<string, any> | null}
+ */
+function unwrapDefineVideoConfigCall(expression) {
+  if (isDefineVideoConfigCall(expression)) {
+    return expression
+  }
+
+  if (!isAstNode(expression)) {
+    return null
+  }
+
+  if (
+    expression.type === 'ParenthesizedExpression' ||
+    expression.type === 'TSAsExpression' ||
+    expression.type === 'TSSatisfiesExpression' ||
+    expression.type === 'TSNonNullExpression'
+  ) {
+    return unwrapDefineVideoConfigCall(expression.expression)
+  }
+
+  return null
+}
+
+/**
+ * @param {{ body: unknown[] }} program
+ * @returns {Array<any>}
+ */
+function collectDefineVideoConfigCalls(program) {
+  /** @type {Array<any>} */
+  const calls = []
+
+  for (const statement of program.body) {
+    if (!isAstNode(statement)) {
+      continue
+    }
+
+    if (statement.type === 'ExpressionStatement') {
+      const call = unwrapDefineVideoConfigCall(statement.expression)
+      if (call) calls.push(call)
+      continue
+    }
+
+    if (statement.type === 'VariableDeclaration') {
+      for (const declaration of statement.declarations) {
+        const call = unwrapDefineVideoConfigCall(declaration.init)
+        if (call) calls.push(call)
+      }
+      continue
+    }
+
+    if (statement.type === 'ExportDefaultDeclaration') {
+      const call = unwrapDefineVideoConfigCall(statement.declaration)
+      if (call) calls.push(call)
+    }
+  }
+
+  return calls
+}
+
+/**
+ * @param {unknown} keyNode
+ * @param {{ filename: string, source: string, contentStartOffset: number }} context
+ * @returns {string}
+  */
+function evaluateObjectKey(keyNode, context) {
+  if (!isAstNode(keyNode)) {
+    throw createParseError(context, 'defineVideoConfig() object keys must be static.', undefined)
+  }
+
+  if (keyNode.type === 'Identifier') {
+    return keyNode.name
+  }
+
+  if (keyNode.type === 'StringLiteral' || keyNode.type === 'NumericLiteral') {
+    return String(keyNode.value)
+  }
+
+  if (keyNode.type === 'TemplateLiteral' && keyNode.expressions.length === 0) {
+    return keyNode.quasis.map((quasi) => quasi.value.cooked ?? quasi.value.raw).join('')
+  }
+
+  throw createParseError(
+    context,
+    'defineVideoConfig() object keys must be plain identifiers or static strings.',
+    keyNode,
+    'Avoid computed keys and expressions in the macro payload.'
+  )
+}
+
+/**
+ * @param {unknown} node
+ * @param {{ filename: string, source: string, contentStartOffset: number }} context
+ * @returns {StaticConfigValue}
+ */
+function evaluateStaticNode(node, context) {
+  if (!isAstNode(node)) {
+    throw createParseError(context, 'defineVideoConfig() contains an unsupported value.', undefined)
+  }
+
+  if (
+    node.type === 'ParenthesizedExpression' ||
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSNonNullExpression'
+  ) {
+    return evaluateStaticNode(node.expression, context)
+  }
+
+  switch (node.type) {
+    case 'StringLiteral':
+    case 'NumericLiteral':
+    case 'BooleanLiteral':
+      return node.value
+
+    case 'NullLiteral':
+      return null
+
+    case 'TemplateLiteral':
+      if (node.expressions.length > 0) {
+        throw createParseError(
+          context,
+          'defineVideoConfig() template strings must be fully static.',
+          node,
+          'Replace interpolated templates with a plain string literal.'
+        )
+      }
+      return node.quasis.map((quasi) => quasi.value.cooked ?? quasi.value.raw).join('')
+
+    case 'UnaryExpression':
+      if ((node.operator === '-' || node.operator === '+') && isAstNode(node.argument) && node.argument.type === 'NumericLiteral') {
+        return node.operator === '-' ? -node.argument.value : node.argument.value
+      }
+      throw createParseError(
+        context,
+        `defineVideoConfig() does not support the unary operator "${node.operator}".`,
+        node,
+        'Use plain static numbers, strings, booleans, null, arrays, or object literals.'
+      )
+
+    case 'ArrayExpression':
+      return node.elements.map((element) => {
+        if (element === null) {
+          throw createParseError(
+            context,
+            'defineVideoConfig() arrays cannot contain holes.',
+            node,
+            'Provide an explicit value for every array entry.'
+          )
+        }
+
+        if (isAstNode(element) && element.type === 'SpreadElement') {
+          throw createParseError(
+            context,
+            'defineVideoConfig() does not support spread syntax inside arrays.',
+            element,
+            'Expand the array to explicit static values.'
+          )
+        }
+
+        return evaluateStaticNode(element, context)
+      })
+
+    case 'ObjectExpression': {
+      /** @type {StaticConfigObject} */
+      const value = {}
+
+      for (const property of node.properties) {
+        if (!isAstNode(property)) {
+          throw createParseError(context, 'defineVideoConfig() contains an unsupported object property.', node)
+        }
+
+        if (property.type === 'SpreadElement') {
+          throw createParseError(
+            context,
+            'defineVideoConfig() does not support spread syntax inside objects.',
+            property,
+            'Write out each property explicitly so the config stays static.'
+          )
+        }
+
+        if (property.type !== 'ObjectProperty') {
+          throw createParseError(
+            context,
+            'defineVideoConfig() only supports plain object properties.',
+            property,
+            'Remove methods, getters, and setters from the macro payload.'
+          )
+        }
+
+        if (property.computed) {
+          throw createParseError(
+            context,
+            'defineVideoConfig() does not support computed property keys.',
+            property,
+            'Use plain identifiers or quoted string keys instead.'
+          )
+        }
+
+        const key = evaluateObjectKey(property.key, context)
+        value[key] = evaluateStaticNode(property.value, context)
+      }
+
+      return value
+    }
+
+    default:
+      throw createParseError(
+        context,
+        `defineVideoConfig() does not support ${node.type} values.`,
+        node,
+        'Use only static strings, numbers, booleans, null, arrays, and object literals.'
+      )
+  }
+}
+
 /**
  * Extract video config from a .vue file.
  *
@@ -41,66 +360,84 @@ const DEFINE_VIDEO_CONFIG_RUNTIME = `((config) => {
  */
 export function extractVideoConfig(filePath) {
   const source = readFileSync(filePath, 'utf-8')
-  return extractVideoConfigFromSource(source)
+  return extractVideoConfigFromSource(source, { filename: filePath })
 }
 
 /**
  * Extract video config from Vue SFC source code.
  *
  * @param {string} source
+ * @param {{ filename?: string }} [options]
  * @returns {VideoConfigLiteral | null}
  */
-export function extractVideoConfigFromSource(source) {
-  // Extract <script setup> content with a regex instead of pulling in
-  // the full @vue/compiler-sfc parser. The block can't nest, so this
-  // is reliable and avoids a heavy dependency.
-  const scriptSetupMatch = source.match(/<script\s+setup[^>]*>([\s\S]*?)<\/script>/)
-  if (!scriptSetupMatch) return null
+export function extractVideoConfigFromSource(source, options = {}) {
+  const filename = options.filename || 'Video.vue'
+  const { descriptor, errors } = parseSfc(source, { filename })
 
-  const match = scriptSetupMatch[1].match(/defineVideoConfig\s*\(\s*(\{[\s\S]*?\})\s*\)/)
-  if (!match) return null
+  if (errors.length > 0) {
+    const firstError = errors[0]
+    const message = firstError instanceof Error ? firstError.message : String(firstError)
+    throw new DefineVideoConfigParseError(`Failed to parse Vue component. ${message}`, { filename })
+  }
 
-  try {
-    return parseObjectLiteral(match[1])
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.warn(`Failed to parse defineVideoConfig: ${message}`)
+  const scriptSetup = descriptor.scriptSetup
+  if (!scriptSetup) {
     return null
   }
-}
 
-/**
- * Parse a static object literal string.
- *
- * @param {string} str
- * @returns {VideoConfigLiteral}
- */
-function parseObjectLiteral(str) {
-  const trimmed = str.trim()
-  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
-    throw new Error('Not an object literal')
+  const contentStartOffset = source.indexOf(scriptSetup.content, scriptSetup.loc.start.offset)
+  const context = {
+    filename,
+    source,
+    contentStartOffset: contentStartOffset >= 0 ? contentStartOffset : scriptSetup.loc.start.offset
   }
 
-  /** @type {Record<string, string | number | boolean | undefined>} */
-  const config = {}
-  const regex = /(\w+)\s*:\s*(-?\d+(?:\.\d+)?|true|false|'[^']*'|"[^"]*")/g
-  let match
-
-  while ((match = regex.exec(trimmed)) !== null) {
-    const key = match[1]
-    const rawValue = match[2]
-    /** @type {string | number | boolean} */
-    let value
-
-    if (rawValue === 'true') value = true
-    else if (rawValue === 'false') value = false
-    else if (rawValue.startsWith("'") || rawValue.startsWith('"')) value = rawValue.slice(1, -1)
-    else value = parseFloat(rawValue)
-
-    config[key] = value
+  let scriptAst
+  try {
+    scriptAst = parseScript(scriptSetup.content, {
+      sourceType: 'module',
+      plugins: getScriptParserPlugins(scriptSetup.lang)
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new DefineVideoConfigParseError(`Failed to parse <script setup>. ${message}`, { filename })
   }
 
-  return /** @type {VideoConfigLiteral} */ (config)
+  const calls = collectDefineVideoConfigCalls(scriptAst.program)
+  if (calls.length === 0) {
+    return null
+  }
+
+  if (calls.length > 1) {
+    throw createParseError(
+      context,
+      'defineVideoConfig() can only be called once per component.',
+      calls[1],
+      'Keep a single top-level macro call and merge the config into one object.'
+    )
+  }
+
+  const [call] = calls
+  if (call.arguments.length !== 1) {
+    throw createParseError(
+      context,
+      'defineVideoConfig() expects exactly one argument.',
+      call,
+      'Pass a single static object literal to the macro.'
+    )
+  }
+
+  const value = evaluateStaticNode(call.arguments[0], context)
+  if (!value || Array.isArray(value) || typeof value !== 'object') {
+    throw createParseError(
+      context,
+      'defineVideoConfig() expects a static object literal.',
+      call.arguments[0],
+      'Wrap the config in `{}` and keep every value static.'
+    )
+  }
+
+  return /** @type {VideoConfigLiteral} */ (value)
 }
 
 /**

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -32,7 +32,7 @@
  * @property {number|string|null} [height]
  * @property {string|null} [audio]
  *
- * @typedef {VideoConfigInput & Record<string, string|number|boolean|undefined>} VideoConfigLiteral
+ * @typedef {VideoConfigInput & Record<string, unknown>} VideoConfigLiteral
  *
  * @typedef {Object} CliVideoConfigFlags
  * @property {number} [duration]

--- a/packages/core/test/define-video-config.test.js
+++ b/packages/core/test/define-video-config.test.js
@@ -1,0 +1,118 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DefineVideoConfigParseError,
+  extractVideoConfigFromSource
+} from '../src/macros/define-video-config.js'
+
+test('extractVideoConfigFromSource returns null when no macro is present', () => {
+  const source = `
+    <script setup>
+    const message = 'hello'
+    </script>
+  `
+
+  assert.equal(extractVideoConfigFromSource(source, { filename: 'NoMacro.vue' }), null)
+})
+
+test('extractVideoConfigFromSource parses static nested config from a TypeScript script setup', () => {
+  const source = `
+    <script setup lang="ts">
+    type Marker = { label: string, at: number }
+
+    defineVideoConfig({
+      fps: 60,
+      durationInSeconds: 4,
+      audio: './theme.mp3',
+      title: \`Launch Day\`,
+      markers: [
+        { label: 'Intro', at: 0 },
+        { label: 'Outro', at: 180 }
+      ],
+      metadata: {
+        palette: ['#0f172a', '#42b883'],
+        published: true,
+        version: 2
+      }
+    } satisfies Record<string, unknown>)
+    </script>
+  `
+
+  assert.deepEqual(extractVideoConfigFromSource(source, { filename: 'Nested.vue' }), {
+    fps: 60,
+    durationInSeconds: 4,
+    audio: './theme.mp3',
+    title: 'Launch Day',
+    markers: [
+      { label: 'Intro', at: 0 },
+      { label: 'Outro', at: 180 }
+    ],
+    metadata: {
+      palette: ['#0f172a', '#42b883'],
+      published: true,
+      version: 2
+    }
+  })
+})
+
+test('extractVideoConfigFromSource rejects non-static values with a clear parse error', () => {
+  const source = `
+    <script setup>
+    const total = 120
+
+    defineVideoConfig({
+      durationInFrames: total
+    })
+    </script>
+  `
+
+  assert.throws(
+    () => extractVideoConfigFromSource(source, { filename: 'NonStatic.vue' }),
+    (error) => {
+      assert.ok(error instanceof DefineVideoConfigParseError)
+      assert.match(error.message, /NonStatic\.vue:\d+:\d+ defineVideoConfig\(\) does not support Identifier values\./)
+      return true
+    }
+  )
+})
+
+test('extractVideoConfigFromSource rejects multiple macro calls', () => {
+  const source = `
+    <script setup>
+    defineVideoConfig({ fps: 30 })
+    defineVideoConfig({ durationInSeconds: 5 })
+    </script>
+  `
+
+  assert.throws(
+    () => extractVideoConfigFromSource(source, { filename: 'Multiple.vue' }),
+    (error) => {
+      assert.ok(error instanceof DefineVideoConfigParseError)
+      assert.match(error.message, /defineVideoConfig\(\) can only be called once per component\./)
+      return true
+    }
+  )
+})
+
+test('extractVideoConfigFromSource rejects spread syntax in the macro payload', () => {
+  const source = `
+    <script setup>
+    const base = { fps: 30 }
+
+    defineVideoConfig({
+      ...base,
+      durationInSeconds: 5
+    })
+    </script>
+  `
+
+  assert.throws(
+    () => extractVideoConfigFromSource(source, { filename: 'Spread.vue' }),
+    (error) => {
+      assert.ok(error instanceof DefineVideoConfigParseError)
+      assert.match(error.message, /defineVideoConfig\(\) does not support spread syntax inside objects\./)
+      return true
+    }
+  )
+})


### PR DESCRIPTION
## What changed
- replaced the regex-based `defineVideoConfig()` extraction with a structured Vue SFC + AST parse path
- evaluate static object, array, primitive, and TypeScript-wrapped macro values directly from the AST instead of partially matching text
- raise clear `DefineVideoConfigParseError` messages with file and location context for unsupported macro shapes
- catch those parser errors in the CLI so users get a clean Pellicule failure instead of a raw stack trace
- add focused coverage for supported nested static config and unsupported shapes like identifiers, multiple macro calls, and spreads
- declare the runtime parser dependencies directly in `packages/core/package.json`

## Why
The old implementation used two layers of regex and a flat primitive parser. That was fragile and could silently misread valid-looking config, which is worse than failing loudly. This change makes `defineVideoConfig()` parsing trustworthy and gives us a safer foundation for expanding the macro over time.

## Impact
- static nested config is now parsed correctly
- unsupported config values fail clearly instead of being partially ignored
- CLI feedback is more actionable when macro parsing fails
- the parser no longer depends on hoisted transitive dependencies working by accident

## Validation
- `npm run typecheck`
- `npm test`

Closes #28
Fixes #28
Resolves #28
