### PR TITLE
Add output presets and codec quality controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,25 @@ npx pellicule Video.vue -d 90 -o hello.mp4
 | Flag | Description | Default |
 |------|-------------|---------|
 | `-o, --output` | Output file path | `./output.mp4` |
+| `--preset` | Output preset (`mp4`, `webm`) | `mp4` |
+| `--quality` | Output quality (`draft`, `standard`, `high`) | `standard` |
 | `-d, --duration` | Duration in frames | `90` |
 | `-f, --fps` | Frames per second | `30` |
 | `-w, --width` | Video width | `1920` |
 | `-h, --height` | Video height | `1080` |
+
+Example output commands:
+
+```bash
+# Default MP4 (H.264 + AAC)
+npx pellicule Video.vue
+
+# WebM output
+npx pellicule Video.vue --preset webm
+
+# Higher-quality MP4
+npx pellicule Video.vue --quality high
+```
 
 ## API
 
@@ -79,7 +94,7 @@ npx pellicule Video.vue -d 90 -o hello.mp4
 
 1. **Vite** bundles your Vue component
 2. **Playwright** renders each frame in a headless browser
-3. **FFmpeg** encodes the frames into an MP4
+3. **FFmpeg** encodes the frames into the selected output format
 
 The rendering is deterministic - the same component produces the exact same video every time.
 

--- a/examples/pellicule/Video.vue
+++ b/examples/pellicule/Video.vue
@@ -183,7 +183,7 @@ const features = useSequence(SCENES.FEATURES.start, SCENES.FEATURES.duration)
 const featureItems = [
   { icon: '◆', text: 'Vue 3 + Vite' },
   { icon: '▲', text: 'Frame-perfect' },
-  { icon: '●', text: 'MP4 output' }
+  { icon: '●', text: 'Preset outputs' }
 ]
 
 const featureStyles = computed(() => {
@@ -401,13 +401,11 @@ const finalOpacity = computed(() =>
 </template>
 
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap');
-
 .video {
   width: 100%;
   height: 100%;
   background: #000;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
   position: relative;
   overflow: hidden;
 }
@@ -503,7 +501,7 @@ const finalOpacity = computed(() =>
 }
 
 .wordmark {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Avenir Next', 'Helvetica Neue', sans-serif;
   font-size: 72px;
   font-weight: 500;
   letter-spacing: -2px;

--- a/packages/core/bin/cli.js
+++ b/packages/core/bin/cli.js
@@ -8,6 +8,13 @@ import { renderToMp4 } from '../src/render.js'
 import { DefineVideoConfigParseError, extractVideoConfig, resolveVideoConfig } from '../src/macros/define-video-config.js'
 import { detectProject, readPelliculeConfig, resolveInputFile } from '../src/config/detect.js'
 import { startDevServer } from '../src/dev/server.js'
+import {
+  DEFAULT_OUTPUT_QUALITY,
+  DEFAULT_OUTPUT_PRESET,
+  OUTPUT_PRESET_NAMES,
+  OUTPUT_QUALITY_NAMES,
+  resolveOutputOptions
+} from '../src/renderer/encode.js'
 
 /**
  * @typedef {import('../src/types.js').BundlerName} BundlerName
@@ -15,6 +22,8 @@ import { startDevServer } from '../src/dev/server.js'
  * @typedef {import('../src/types.js').DetectedProject} DetectedProject
  * @typedef {import('../src/types.js').InputResolutionFailure} InputResolutionFailure
  * @typedef {import('../src/types.js').InputResolutionSuccess} InputResolutionSuccess
+ * @typedef {import('../src/types.js').OutputPresetName} OutputPresetName
+ * @typedef {import('../src/types.js').OutputQuality} OutputQuality
  * @typedef {import('../src/types.js').ProjectType} ProjectType
  * @typedef {import('../src/types.js').RenderProgress} RenderProgress
  * @typedef {import('../src/types.js').VideoConfigLiteral} VideoConfigLiteral
@@ -79,6 +88,8 @@ ${c.bold('USAGE')}
 
 ${c.bold('OPTIONS')}
   ${c.info('-o, --output')} <file>     Output file path ${c.dim('(default: ./output.mp4)')}
+  ${c.info('--preset')} <name>         Output preset: ${OUTPUT_PRESET_NAMES.join(', ')} ${c.dim(`(default: ${DEFAULT_OUTPUT_PRESET})`)}
+  ${c.info('--quality')} <level>       Output quality: ${OUTPUT_QUALITY_NAMES.join(', ')} ${c.dim(`(default: ${DEFAULT_OUTPUT_QUALITY})`)}
   ${c.info('-d, --duration')} <frames> Duration in frames ${c.dim('(default: from component or 90)')}
   ${c.info('-f, --fps')} <number>      Frames per second ${c.dim('(default: from component or 30)')}
   ${c.info('-w, --width')} <pixels>    Video width ${c.dim('(default: from component or 1920)')}
@@ -140,6 +151,12 @@ ${c.bold('EXAMPLES')}
 
   ${c.dim('# Force Rsbuild bundler')}
   ${c.highlight('pellicule')} Video.vue --bundler rsbuild
+
+  ${c.dim('# Render a WebM for the web')}
+  ${c.highlight('pellicule')} Video.vue --preset webm
+
+  ${c.dim('# Pick a higher-quality encode')}
+  ${c.highlight('pellicule')} Video.vue --quality high
 
   ${c.dim('# Live preview with hot-reload (Space to play, arrows to step)')}
   ${c.highlight('pellicule dev')}
@@ -208,6 +225,30 @@ function parseBundlerName(value) {
 }
 
 /**
+ * @param {string | undefined} value
+ * @returns {OutputPresetName | undefined}
+ */
+function parseOutputPreset(value) {
+  if (value && OUTPUT_PRESET_NAMES.some((preset) => preset === value)) {
+    return /** @type {OutputPresetName} */ (value)
+  }
+
+  return undefined
+}
+
+/**
+ * @param {string | undefined} value
+ * @returns {OutputQuality | undefined}
+ */
+function parseOutputQuality(value) {
+  if (value && OUTPUT_QUALITY_NAMES.some((quality) => quality === value)) {
+    return /** @type {OutputQuality} */ (value)
+  }
+
+  return undefined
+}
+
+/**
  * @param {import('../src/config/detect.js').resolveInputFile extends (...args: any[]) => infer R ? R : never} result
  * @returns {result is InputResolutionFailure}
  */
@@ -220,6 +261,8 @@ async function main() {
     allowPositionals: true,
     options: {
       output: { type: 'string', short: 'o' },
+      preset: { type: 'string' },
+      quality: { type: 'string' },
       duration: { type: 'string', short: 'd' },
       fps: { type: 'string', short: 'f' },
       width: { type: 'string', short: 'w' },
@@ -257,6 +300,8 @@ async function main() {
 
   // Resolution: CLI flags > package.json "pellicule" key > auto-detected
   const cliBundler = parseBundlerName(values.bundler)
+  const cliPreset = parseOutputPreset(values.preset)
+  const cliQuality = parseOutputQuality(values.quality)
   const bundler = cliBundler || pkgConfig.bundler || detected.bundler
   const configFile = values.config ? resolve(values.config) : detected.configFile
   const videosDir = values['videos-dir'] ? resolve(values['videos-dir']) : pkgConfig.videosDir || detected.videosDir
@@ -278,6 +323,12 @@ async function main() {
   // Validate bundler flag
   if (values.bundler && !cliBundler) {
     fail(`Unknown bundler: ${values.bundler}`, 'Supported bundlers: vite, rsbuild')
+  }
+  if (values.preset && !cliPreset) {
+    fail(`Unknown output preset: ${values.preset}`, `Supported presets: ${OUTPUT_PRESET_NAMES.join(', ')}`)
+  }
+  if (values.quality && !cliQuality) {
+    fail(`Unknown output quality: ${values.quality}`, `Supported qualities: ${OUTPUT_QUALITY_NAMES.join(', ')}`)
   }
 
   // ── Input file resolution ─────────────────────────────────────────
@@ -333,17 +384,27 @@ async function main() {
   const durationInFrames = resolvedConfig.durationInFrames
   const width = resolvedConfig.width
   const height = resolvedConfig.height
-  let output
+  const componentName = basename(inputPath, '.vue')
+  let outputBase
   if (values.output) {
-    output = values.output
+    outputBase = values.output
   } else if (outDir) {
     // Use component name as filename when outDir is configured
-    const componentName = basename(inputPath, '.vue')
-    output = join(outDir, `${componentName}.mp4`)
+    outputBase = join(outDir, componentName)
   } else {
-    output = './output.mp4'
+    outputBase = './output'
   }
-  const outputPath = resolve(output)
+  let resolvedOutput
+  try {
+    resolvedOutput = resolveOutputOptions({
+      output: outputBase,
+      preset: cliPreset,
+      quality: cliQuality
+    })
+  } catch (error) {
+    fail(getErrorMessage(error))
+  }
+  const outputPath = resolve(resolvedOutput.output)
 
   // Parse optional range (start:end format)
   let startFrame = 0
@@ -449,6 +510,8 @@ async function main() {
   }
 
   console.log(`  ${c.bold('Output')}     ${c.info(basename(outputPath))}`)
+  console.log(`  ${c.bold('Preset')}     ${c.info(resolvedOutput.preset)}`)
+  console.log(`  ${c.bold('Quality')}    ${c.info(resolvedOutput.quality)}`)
   console.log(`  ${c.bold('Resolution')} ${width}x${height}`)
   console.log(`  ${c.bold('Duration')}   ${durationInFrames} frames @ ${fps}fps ${c.dim(`(${durationSeconds}s)`)}`)
   if (isPartialRender) {
@@ -486,6 +549,8 @@ async function main() {
       height,
       output: outputPath,
       audio: audioPath,
+      preset: resolvedOutput.preset,
+      quality: resolvedOutput.quality,
       silent: true,
       serverUrl: finalServerUrl,
       bundler,

--- a/packages/core/src/renderer/encode.js
+++ b/packages/core/src/renderer/encode.js
@@ -3,34 +3,174 @@ import path from 'path'
 
 /**
  * @typedef {import('../types.js').EncodeVideoOptions} EncodeVideoOptions
+ * @typedef {import('../types.js').OutputPresetName} OutputPresetName
+ * @typedef {import('../types.js').OutputQuality} OutputQuality
  * @typedef {import('../types.js').RenderToMp4Options} RenderToMp4Options
  * @typedef {import('../types.js').RenderVideoOptions} RenderVideoOptions
  */
 
+/** @type {OutputPresetName} */
+export const DEFAULT_OUTPUT_PRESET = 'mp4'
+/** @type {OutputQuality} */
+export const DEFAULT_OUTPUT_QUALITY = 'standard'
+/** @type {OutputPresetName[]} */
+export const OUTPUT_PRESET_NAMES = ['mp4', 'webm']
+/** @type {OutputQuality[]} */
+export const OUTPUT_QUALITY_NAMES = ['draft', 'standard', 'high']
+
+const OUTPUT_PRESETS = {
+  mp4: {
+    extension: '.mp4',
+    videoCodec: 'libx264',
+    audioCodec: 'aac',
+    videoArgs: ['-pix_fmt', 'yuv420p'],
+    qualityArgs: {
+      draft: {
+        video: ['-preset', 'veryfast', '-crf', '28'],
+        audio: ['-b:a', '128k']
+      },
+      standard: {
+        video: ['-preset', 'fast', '-crf', '23'],
+        audio: ['-b:a', '192k']
+      },
+      high: {
+        video: ['-preset', 'slow', '-crf', '18'],
+        audio: ['-b:a', '256k']
+      }
+    }
+  },
+  webm: {
+    extension: '.webm',
+    videoCodec: 'libvpx-vp9',
+    audioCodec: 'libopus',
+    videoArgs: [],
+    qualityArgs: {
+      draft: {
+        video: ['-b:v', '0', '-crf', '38', '-deadline', 'realtime', '-cpu-used', '6'],
+        audio: ['-b:a', '96k']
+      },
+      standard: {
+        video: ['-b:v', '0', '-crf', '32', '-deadline', 'good', '-cpu-used', '4'],
+        audio: ['-b:a', '128k']
+      },
+      high: {
+        video: ['-b:v', '0', '-crf', '24', '-deadline', 'good', '-cpu-used', '2'],
+        audio: ['-b:a', '160k']
+      }
+    }
+  }
+}
+
 /**
- * @param {{ output?: string, fps?: number, audio?: string|null }} options
+ * @param {string} output
+ * @returns {OutputPresetName | null}
+ */
+function inferPresetFromOutput(output) {
+  const extension = path.extname(output).toLowerCase()
+
+  for (const presetName of OUTPUT_PRESET_NAMES) {
+    if (OUTPUT_PRESETS[presetName].extension === extension) {
+      return presetName
+    }
+  }
+
+  return extension ? null : DEFAULT_OUTPUT_PRESET
+}
+
+/**
+ * @param {OutputPresetName} preset
+ * @returns {typeof OUTPUT_PRESETS[OutputPresetName]}
+ */
+function getOutputPreset(preset) {
+  return OUTPUT_PRESETS[preset]
+}
+
+/**
+ * @param {{ output?: string, preset?: OutputPresetName, quality?: OutputQuality }} options
+ * @returns {{ output: string, preset: OutputPresetName, quality: OutputQuality }}
+ */
+export function resolveOutputOptions(options = {}) {
+  const requestedOutput = options.output || './output'
+  const inferredPreset = inferPresetFromOutput(requestedOutput)
+  const preset = options.preset || inferredPreset || DEFAULT_OUTPUT_PRESET
+
+  if (!OUTPUT_PRESET_NAMES.includes(preset)) {
+    throw new Error(`Unknown output preset: ${preset}`)
+  }
+
+  const quality = options.quality || DEFAULT_OUTPUT_QUALITY
+  if (!OUTPUT_QUALITY_NAMES.includes(quality)) {
+    throw new Error(`Unknown output quality: ${quality}`)
+  }
+
+  const presetConfig = getOutputPreset(preset)
+  const extension = path.extname(requestedOutput).toLowerCase()
+
+  if (extension && extension !== presetConfig.extension) {
+    throw new Error(
+      `Output file extension "${extension}" does not match the ${preset} preset (${presetConfig.extension})`
+    )
+  }
+
+  return {
+    output: extension ? requestedOutput : `${requestedOutput}${presetConfig.extension}`,
+    preset,
+    quality
+  }
+}
+
+/**
+ * @param {{
+ *   output?: string,
+ *   fps?: number,
+ *   audio?: string|null,
+ *   preset?: OutputPresetName,
+ *   quality?: OutputQuality,
+ *   inputArgs: string[]
+ * }} options
+ * @returns {string[]}
+ */
+function createEncodeArgs(options) {
+  const {
+    fps = 30,
+    audio = null,
+    inputArgs
+  } = options
+  const resolved = resolveOutputOptions(options)
+  const preset = getOutputPreset(resolved.preset)
+  const qualityArgs = preset.qualityArgs[resolved.quality]
+
+  return [
+    '-y',
+    ...inputArgs,
+    ...(audio ? ['-i', audio] : []),
+    '-c:v', preset.videoCodec,
+    ...preset.videoArgs,
+    ...qualityArgs.video,
+    ...(audio ? ['-c:a', preset.audioCodec, ...qualityArgs.audio] : []),
+    resolved.output
+  ]
+}
+
+/**
+ * @param {{
+ *   output?: string,
+ *   fps?: number,
+ *   audio?: string|null,
+ *   preset?: OutputPresetName,
+ *   quality?: OutputQuality
+ * }} options
  * @returns {string[]}
  */
 export function createPipeEncodeArgs(options) {
   const {
-    output = './output.mp4',
-    fps = 30,
-    audio = null
+    fps = 30
   } = options
 
-  return [
-    '-y',
-    '-f', 'image2pipe',
-    '-vcodec', 'png',
-    '-framerate', String(fps),
-    '-i', 'pipe:0',
-    ...(audio ? ['-i', audio] : []),
-    '-c:v', 'libx264',
-    '-pix_fmt', 'yuv420p',
-    '-preset', 'fast',
-    ...(audio ? ['-c:a', 'aac'] : []),
-    output
-  ]
+  return createEncodeArgs({
+    ...options,
+    inputArgs: ['-f', 'image2pipe', '-vcodec', 'png', '-framerate', String(fps), '-i', 'pipe:0']
+  })
 }
 
 /**
@@ -121,26 +261,20 @@ function spawnFfmpeg(options) {
  * @returns {Promise<string>} Path to the output video
  */
 export function encodeVideo(options) {
-  const { framesDir, output = './output.mp4', fps = 30, audio = null, silent = false } = options
+  const { framesDir, fps = 30, silent = false } = options
   const framePattern = path.join(framesDir, 'frame-%05d.png')
-  const args = [
-    '-y',
-    '-framerate', String(fps),
-    '-i', framePattern,
-    ...(audio ? ['-i', audio] : []),
-    '-c:v', 'libx264',
-    '-pix_fmt', 'yuv420p',
-    '-preset', 'fast',
-    ...(audio ? ['-c:a', 'aac'] : []),
-    output
-  ]
+  const args = createEncodeArgs({
+    ...options,
+    fps,
+    inputArgs: ['-framerate', String(fps), '-i', framePattern]
+  })
 
   const { done } = spawnFfmpeg({ args, silent })
   return done
 }
 
 /**
- * Full render pipeline: Vue component → frames → MP4
+ * Full render pipeline: Vue component → frames → encoded video
  *
  * @param {RenderToMp4Options} options - Same as renderVideo, plus output path
  * @returns {Promise<string>} Path to the output video
@@ -148,17 +282,24 @@ export function encodeVideo(options) {
 export async function renderToMp4(options) {
   const { streamVideoFrames } = await import('./render.js')
 
-  const { output = './output.mp4', audio = null, silent = false, ...rawRenderOptions } = options
+  const { audio = null, preset, quality, silent = false, ...rawRenderOptions } = options
   /** @type {RenderVideoOptions} */
   const renderOptions = rawRenderOptions
+  const resolvedOutput = resolveOutputOptions({
+    output: options.output,
+    preset,
+    quality
+  })
 
   /** @type {(() => Promise<void>) | null} */
   let cleanup = null
   const { ffmpeg, done } = spawnFfmpeg({
     args: createPipeEncodeArgs({
-      output,
+      output: resolvedOutput.output,
       fps: renderOptions.fps || 30,
-      audio
+      audio,
+      preset: resolvedOutput.preset,
+      quality: resolvedOutput.quality
     }),
     silent
   })

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -173,16 +173,24 @@
  * @property {number} totalFrames
  * @property {AsyncCleanup} cleanup
  *
+ * @typedef {'mp4'|'webm'} OutputPresetName
+ *
+ * @typedef {'draft'|'standard'|'high'} OutputQuality
+ *
  * @typedef {Object} EncodeVideoOptions
  * @property {string} framesDir
  * @property {string} [output]
  * @property {number} [fps]
  * @property {string|null} [audio]
+ * @property {OutputPresetName} [preset]
+ * @property {OutputQuality} [quality]
  * @property {boolean} [silent]
  *
  * @typedef {RenderVideoOptions & {
  *   output?: string,
  *   audio?: string|null,
+ *   preset?: OutputPresetName,
+ *   quality?: OutputQuality,
  *   silent?: boolean
  * }} RenderToMp4Options
  *

--- a/packages/core/test/encode.test.js
+++ b/packages/core/test/encode.test.js
@@ -1,13 +1,65 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { createPipeEncodeArgs } from '../src/renderer/encode.js'
+import {
+  createPipeEncodeArgs,
+  resolveOutputOptions
+} from '../src/renderer/encode.js'
 
-test('createPipeEncodeArgs builds ffmpeg args for streamed PNG input', () => {
+test('resolveOutputOptions keeps the default mp4 output model', () => {
+  const resolved = resolveOutputOptions()
+
+  assert.deepEqual(resolved, {
+    output: './output.mp4',
+    preset: 'mp4',
+    quality: 'standard'
+  })
+})
+
+test('resolveOutputOptions infers webm from the output extension', () => {
+  const resolved = resolveOutputOptions({ output: './demo.webm' })
+
+  assert.deepEqual(resolved, {
+    output: './demo.webm',
+    preset: 'webm',
+    quality: 'standard'
+  })
+})
+
+test('resolveOutputOptions uses the preset extension when no output path is provided', () => {
+  const resolved = resolveOutputOptions({ preset: 'webm' })
+
+  assert.deepEqual(resolved, {
+    output: './output.webm',
+    preset: 'webm',
+    quality: 'standard'
+  })
+})
+
+test('resolveOutputOptions appends the preset extension when output has no extension', () => {
+  const resolved = resolveOutputOptions({ output: './exports/demo', preset: 'webm', quality: 'high' })
+
+  assert.deepEqual(resolved, {
+    output: './exports/demo.webm',
+    preset: 'webm',
+    quality: 'high'
+  })
+})
+
+test('resolveOutputOptions rejects mismatched preset and file extension', () => {
+  assert.throws(
+    () => resolveOutputOptions({ output: './demo.mp4', preset: 'webm' }),
+    /does not match the webm preset/
+  )
+})
+
+test('createPipeEncodeArgs builds ffmpeg args for streamed png mp4 output', () => {
   const args = createPipeEncodeArgs({
     output: './video.mp4',
     fps: 60,
-    audio: './song.mp3'
+    audio: './song.mp3',
+    preset: 'mp4',
+    quality: 'standard'
   })
 
   assert.deepEqual(args, [
@@ -20,7 +72,32 @@ test('createPipeEncodeArgs builds ffmpeg args for streamed PNG input', () => {
     '-c:v', 'libx264',
     '-pix_fmt', 'yuv420p',
     '-preset', 'fast',
+    '-crf', '23',
     '-c:a', 'aac',
+    '-b:a', '192k',
     './video.mp4'
+  ])
+})
+
+test('createPipeEncodeArgs builds ffmpeg args for streamed png webm output', () => {
+  const args = createPipeEncodeArgs({
+    output: './video.webm',
+    fps: 30,
+    preset: 'webm',
+    quality: 'draft'
+  })
+
+  assert.deepEqual(args, [
+    '-y',
+    '-f', 'image2pipe',
+    '-vcodec', 'png',
+    '-framerate', '30',
+    '-i', 'pipe:0',
+    '-c:v', 'libvpx-vp9',
+    '-b:v', '0',
+    '-crf', '38',
+    '-deadline', 'realtime',
+    '-cpu-used', '6',
+    './video.webm'
   ])
 })


### PR DESCRIPTION
## What this changes
- add a small output model with `mp4` and `webm` presets instead of one hard-coded encode path
- add `--quality draft|standard|high` with codec-specific FFmpeg settings
- keep the zero-config MP4 path as the default behavior
- validate output extension and preset combinations clearly in the CLI
- make the bundled `examples/pellicule` demo self-contained by removing remote font imports that could stall render readiness

## Verification
- `npm test`
- `npm run typecheck`
- MP4 smoke render
- WebM smoke render
- MP4 + audio smoke render
- WebM + audio smoke render
- bundled example matrix:
  - `examples/karaoke` mp4/webm
  - `examples/pellicule` mp4/webm
  - `examples/sequence` mp4/webm
  - `examples/skills` mp4/webm

Closes #30