### PR TITLE
Add automated coverage for detection and render core

### DIFF
--- a/packages/core/src/renderer/render.js
+++ b/packages/core/src/renderer/render.js
@@ -18,6 +18,30 @@ import { join, dirname } from 'path'
  */
 
 /**
+ * @typedef {{
+ *   goto: (url: string, options: { waitUntil: 'networkidle' }) => Promise<unknown>,
+ *   waitForFunction: (callback: () => boolean, options: { timeout: number }) => Promise<unknown>,
+ *   evaluate: (callback: (...args: any[]) => unknown, ...args: any[]) => Promise<any>
+ * }} RenderPageLike
+ */
+
+/**
+ * @typedef {{
+ *   page: RenderPageLike,
+ *   url: string,
+ *   fps: number,
+ *   width: number,
+ *   height: number,
+ *   durationInFrames: number,
+ *   startFrame: number,
+ *   actualEndFrame: number,
+ *   framesToRender: number,
+ *   onProgress?: ProgressCallback,
+ *   log: (...args: any[]) => void
+ * }} RenderSessionLike
+ */
+
+/**
  * Create a video server using the appropriate bundler adapter.
  *
  * @param {BundlerServerOptions} options
@@ -35,6 +59,22 @@ export async function startBundlerServer(options) {
   // Default: Vite adapter (always available)
   const { createVideoServer } = await import('../bundler/vite.js')
   return createVideoServer(serverOptions)
+}
+
+/**
+ * Build the renderer page URL with the active runtime config encoded as query params.
+ *
+ * @param {string} url
+ * @param {{ fps: number, durationInFrames: number, width: number, height: number }} options
+ * @returns {string}
+ */
+export function buildRenderPageUrl(url, options) {
+  const resolved = new URL(url, 'http://localhost')
+  resolved.searchParams.set('fps', String(options.fps))
+  resolved.searchParams.set('duration', String(options.durationInFrames))
+  resolved.searchParams.set('width', String(options.width))
+  resolved.searchParams.set('height', String(options.height))
+  return resolved.toString()
 }
 
 /**
@@ -149,11 +189,11 @@ async function createRenderSession(options) {
 }
 
 /**
- * @param {Awaited<ReturnType<typeof createRenderSession>>} session
+ * @param {RenderSessionLike} session
  * @param {(context: RenderFrameContext) => Promise<void>} handleFrame
  * @returns {Promise<void>}
  */
-async function renderFrameSequence(session, handleFrame) {
+export async function renderFrameSequence(session, handleFrame) {
   const {
     page,
     url,
@@ -173,8 +213,7 @@ async function renderFrameSequence(session, handleFrame) {
     : ''
   log(`Rendering ${framesToRender} frames at ${fps}fps (${width}x${height})${rangeInfo}`)
 
-  const separator = url.includes('?') ? '&' : '?'
-  const pageUrl = `${url}${separator}fps=${fps}&duration=${durationInFrames}&width=${width}&height=${height}`
+  const pageUrl = buildRenderPageUrl(url, { fps, durationInFrames, width, height })
   await page.goto(pageUrl, { waitUntil: 'networkidle' })
   await page.waitForFunction(() => /** @type {PelliculeWindow} */ (window).__PELLICULE_READY__ === true, { timeout: 10000 })
 
@@ -189,7 +228,11 @@ async function renderFrameSequence(session, handleFrame) {
     await page.evaluate((f) => /** @type {PelliculeWindow} */ (window).__PELLICULE_SET_FRAME__?.(f), frame)
 
     const outputFrameNum = frame - startFrame
-    await handleFrame({ page, frame, outputFrameNum })
+    await handleFrame({
+      page: /** @type {import('playwright').Page} */ (page),
+      frame,
+      outputFrameNum
+    })
 
     if (onProgress) {
       const elapsed = Date.now() - renderStart

--- a/packages/core/test/detect.test.js
+++ b/packages/core/test/detect.test.js
@@ -1,0 +1,154 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { detectProject, readPelliculeConfig, resolveInputFile } from '../src/config/detect.js'
+
+/**
+ * @param {string} prefix
+ * @returns {Promise<string>}
+ */
+async function createFixtureDir(prefix) {
+  return await mkdtemp(join(tmpdir(), prefix))
+}
+
+/**
+ * @param {string} root
+ * @param {string} relativePath
+ * @param {string} [contents]
+ * @returns {Promise<void>}
+ */
+async function writeFixture(root, relativePath, contents = '') {
+  const fullPath = join(root, relativePath)
+  await mkdir(join(fullPath, '..'), { recursive: true })
+  await writeFile(fullPath, contents)
+}
+
+test('detectProject identifies Laravel projects before plain Vite', async () => {
+  const root = await createFixtureDir('pellicule-detect-laravel-')
+
+  try {
+    await writeFixture(root, 'artisan')
+    await writeFixture(root, 'vite.config.js', 'export default {}')
+
+    assert.deepEqual(detectProject(root), {
+      projectType: 'laravel',
+      bundler: 'vite',
+      configFile: join(root, 'vite.config.js'),
+      videosDir: join(root, 'resources', 'js', 'videos'),
+      byos: false
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('detectProject identifies Nuxt projects with BYOS defaults', async () => {
+  const root = await createFixtureDir('pellicule-detect-nuxt-')
+
+  try {
+    await writeFixture(root, 'nuxt.config.ts', 'export default defineNuxtConfig({})')
+
+    assert.deepEqual(detectProject(root), {
+      projectType: 'nuxt',
+      bundler: 'vite',
+      configFile: join(root, 'nuxt.config.ts'),
+      videosDir: join(root, 'app', 'videos'),
+      byos: true,
+      defaultServerUrl: 'http://localhost:3000'
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('detectProject falls back to standalone when no framework config exists', async () => {
+  const root = await createFixtureDir('pellicule-detect-standalone-')
+
+  try {
+    assert.deepEqual(detectProject(root), {
+      projectType: 'standalone',
+      bundler: 'vite',
+      configFile: null,
+      videosDir: root,
+      byos: false
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('readPelliculeConfig resolves supported package.json options', async () => {
+  const root = await createFixtureDir('pellicule-config-')
+
+  try {
+    await writeFixture(root, 'package.json', JSON.stringify({
+      pellicule: {
+        serverUrl: 'http://localhost:4100',
+        videosDir: 'custom/videos',
+        outDir: 'renders',
+        bundler: 'rsbuild'
+      }
+    }))
+
+    assert.deepEqual(readPelliculeConfig(root), {
+      serverUrl: 'http://localhost:4100',
+      videosDir: join(root, 'custom', 'videos'),
+      outDir: join(root, 'renders'),
+      bundler: 'rsbuild'
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('readPelliculeConfig ignores invalid package.json content', async () => {
+  const root = await createFixtureDir('pellicule-config-invalid-')
+
+  try {
+    await writeFixture(root, 'package.json', '{ not valid json')
+    assert.deepEqual(readPelliculeConfig(root), {})
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveInputFile finds exact and videosDir-relative component paths', async () => {
+  const root = await createFixtureDir('pellicule-input-')
+  const videosDir = join(root, 'src', 'videos')
+
+  try {
+    await writeFixture(root, 'Video.vue', '<template />')
+    await writeFixture(root, 'src/videos/Intro.vue', '<template />')
+
+    assert.deepEqual(resolveInputFile(join(root, 'Video.vue'), videosDir), {
+      resolved: join(root, 'Video.vue')
+    })
+
+    assert.deepEqual(resolveInputFile('Intro', videosDir), {
+      resolved: join(videosDir, 'Intro.vue')
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveInputFile reports every searched path when the component is missing', async () => {
+  const root = await createFixtureDir('pellicule-input-missing-')
+  const videosDir = join(root, 'src', 'videos')
+
+  try {
+    assert.deepEqual(resolveInputFile('Missing', videosDir), {
+      error: 'File not found: Missing',
+      searched: [
+        resolve('Missing'),
+        resolve('Missing.vue'),
+        join(videosDir, 'Missing.vue')
+      ]
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/packages/core/test/render.test.js
+++ b/packages/core/test/render.test.js
@@ -1,0 +1,133 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildRenderPageUrl, renderFrameSequence } from '../src/renderer/render.js'
+
+/**
+ * @param {{ ready?: boolean, error?: string|null }} [options]
+ * @returns {{
+ *   page: {
+ *     gotoCalls: Array<{ url: string, options: { waitUntil: 'networkidle' } }>,
+ *     setFrames: number[],
+ *     goto: (url: string, options: { waitUntil: 'networkidle' }) => Promise<void>,
+ *     waitForFunction: (callback: () => boolean, options: { timeout: number }) => Promise<void>,
+ *     evaluate: (callback: (...args: any[]) => unknown, ...args: any[]) => Promise<any>
+ *   },
+ *   waitCalls: Array<{ timeout: number }>
+ * }}
+ */
+function createMockPage(options = {}) {
+  const gotoCalls = []
+  const waitCalls = []
+  const setFrames = []
+  const ready = options.ready ?? true
+  const error = options.error ?? null
+  let evaluateCallCount = 0
+
+  return {
+    page: {
+      gotoCalls,
+      setFrames,
+      async goto(url, gotoOptions) {
+        gotoCalls.push({ url, options: gotoOptions })
+      },
+      async waitForFunction(callback, waitOptions) {
+        waitCalls.push(waitOptions)
+        assert.equal(typeof callback, 'function')
+        assert.equal(ready, true)
+      },
+      async evaluate(_callback, ...args) {
+        evaluateCallCount += 1
+
+        if (evaluateCallCount === 1) {
+          return error
+        }
+
+        if (args.length > 0) {
+          setFrames.push(args[0])
+        }
+
+        return undefined
+      }
+    },
+    waitCalls
+  }
+}
+
+test('buildRenderPageUrl merges render config into the target URL', () => {
+  const url = buildRenderPageUrl('http://localhost:3000/pellicule?component=Demo&preview=1', {
+    fps: 60,
+    durationInFrames: 180,
+    width: 1080,
+    height: 1920
+  })
+
+  assert.equal(
+    url,
+    'http://localhost:3000/pellicule?component=Demo&preview=1&fps=60&duration=180&width=1080&height=1920'
+  )
+})
+
+test('renderFrameSequence drives a minimal render loop and reports progress', async () => {
+  const { page, waitCalls } = createMockPage()
+  const handledFrames = []
+  const progress = []
+  const logs = []
+
+  await renderFrameSequence({
+    page,
+    url: 'http://localhost:4173/pellicule?component=Demo',
+    fps: 30,
+    width: 1920,
+    height: 1080,
+    durationInFrames: 8,
+    startFrame: 2,
+    actualEndFrame: 5,
+    framesToRender: 3,
+    onProgress: (entry) => {
+      progress.push(entry)
+    },
+    log: (...args) => {
+      logs.push(args.join(' '))
+    }
+  }, async ({ frame, outputFrameNum }) => {
+    handledFrames.push({ frame, outputFrameNum })
+  })
+
+  assert.deepEqual(page.gotoCalls, [{
+    url: 'http://localhost:4173/pellicule?component=Demo&fps=30&duration=8&width=1920&height=1080',
+    options: { waitUntil: 'networkidle' }
+  }])
+  assert.deepEqual(waitCalls, [{ timeout: 10000 }])
+  assert.deepEqual(page.setFrames, [2, 3, 4])
+  assert.deepEqual(handledFrames, [
+    { frame: 2, outputFrameNum: 0 },
+    { frame: 3, outputFrameNum: 1 },
+    { frame: 4, outputFrameNum: 2 }
+  ])
+  assert.equal(progress.length, 3)
+  assert.equal(progress[2].frame, 2)
+  assert.equal(progress[2].total, 3)
+  assert.match(logs[0], /Rendering 3 frames at 30fps/)
+  assert.match(logs.at(-1) || '', /Rendered 3 frames in/)
+})
+
+test('renderFrameSequence throws when the page reports a render error', async () => {
+  const { page } = createMockPage({ error: 'kaboom' })
+
+  await assert.rejects(
+    renderFrameSequence({
+      page,
+      url: 'http://localhost:4173',
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 4,
+      startFrame: 0,
+      actualEndFrame: 1,
+      framesToRender: 1,
+      log: () => {}
+    }, async () => {}),
+    /Render error: kaboom/
+  )
+})


### PR DESCRIPTION
Closes #32

## What changed
- add unit coverage for project detection, package config parsing, and input resolution
- add render-loop smoke coverage for render URL construction, frame stepping, progress reporting, and surfaced render errors
- make the render frame-sequence seam testable without introducing a heavy browser dependency into CI

## Verification
- `npm test`
- `npm run typecheck`