### PR TITLE
fix: improve cross-platform dev browser launch

### DIFF
--- a/packages/core/src/dev/server.js
+++ b/packages/core/src/dev/server.js
@@ -18,19 +18,65 @@ import { startBundlerServer } from '../renderer/render.js'
  * @typedef {import('../types.js').AsyncCleanup} AsyncCleanup
  * @typedef {import('../types.js').DevServerOptions} DevServerOptions
  * @typedef {import('../types.js').DevServerResult} DevServerResult
+ * @typedef {(command: string, args: string[], options: { windowsHide: boolean }, callback: (error: Error|null) => void) => { unref?: () => void } | undefined} ExecFileLike
  */
 
 /**
- * Open a URL in the user's default browser using platform-native commands.
- * Uses execFile (not exec) to avoid shell injection.
  * @param {string} url
- * @returns {void}
+ * @param {NodeJS.Platform} [platform=process.platform]
+ * @returns {{ command: string, args: string[] }}
  */
-function openBrowser(url) {
-  const cmd = process.platform === 'darwin' ? 'open'
-    : process.platform === 'win32' ? 'start'
-    : 'xdg-open'
-  execFile(cmd, [url], () => {})
+export function getBrowserOpenCommand(url, platform = process.platform) {
+  if (platform === 'darwin') {
+    return { command: 'open', args: [url] }
+  }
+
+  if (platform === 'win32') {
+    return {
+      command: 'cmd',
+      args: ['/d', '/s', '/c', `start "" "${url.replaceAll('"', '""')}"`]
+    }
+  }
+
+  return { command: 'xdg-open', args: [url] }
+}
+
+/**
+ * Open a URL in the user's default browser using platform-native commands.
+ * Uses execFile (not exec) to avoid shell injection where possible.
+ *
+ * @param {string} url
+ * @param {{
+ *   platform?: NodeJS.Platform,
+ *   execFileRef?: ExecFileLike
+ * }} [options]
+ * @returns {Promise<void>}
+ */
+export function openBrowser(url, options = {}) {
+  const { platform = process.platform, execFileRef = execFile } = options
+  const { command, args } = getBrowserOpenCommand(url, platform)
+
+  return new Promise((resolve, reject) => {
+    const child = execFileRef(
+      command,
+      args,
+      {
+        windowsHide: true
+      },
+      (error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      }
+    )
+
+    if (typeof child?.unref === 'function') {
+      child.unref()
+    }
+  })
 }
 
 /**
@@ -119,8 +165,13 @@ export async function startDevServer(options) {
     fullUrl.searchParams.set('audio-duration', String(audioDurationInSeconds))
   }
 
-  // Open in the user's default browser
-  openBrowser(fullUrl.toString())
+  try {
+    await openBrowser(fullUrl.toString())
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`\nPellicule could not open your browser automatically: ${message}`)
+    console.warn(`Open this URL manually:\n  ${fullUrl.toString()}\n`)
+  }
 
   /** @type {AsyncCleanup} */
   const cleanup = async () => {

--- a/packages/core/test/dev-server.test.js
+++ b/packages/core/test/dev-server.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getBrowserOpenCommand, openBrowser } from '../src/dev/server.js'
+
+test('getBrowserOpenCommand uses open on macOS', () => {
+  assert.deepEqual(
+    getBrowserOpenCommand('http://localhost:5173', 'darwin'),
+    {
+      command: 'open',
+      args: ['http://localhost:5173']
+    }
+  )
+})
+
+test('getBrowserOpenCommand uses cmd start with a quoted URL on Windows', () => {
+  assert.deepEqual(
+    getBrowserOpenCommand('http://localhost:5173/pellicule?preview=1&fps=30', 'win32'),
+    {
+      command: 'cmd',
+      args: ['/d', '/s', '/c', 'start "" "http://localhost:5173/pellicule?preview=1&fps=30"']
+    }
+  )
+})
+
+test('getBrowserOpenCommand uses xdg-open on Linux', () => {
+  assert.deepEqual(
+    getBrowserOpenCommand('http://localhost:5173', 'linux'),
+    {
+      command: 'xdg-open',
+      args: ['http://localhost:5173']
+    }
+  )
+})
+
+test('openBrowser resolves after launching the opener command', async () => {
+  /** @type {{ command?: string, args?: string[], options?: { windowsHide: boolean }, unrefCalled: boolean }} */
+  const call = { unrefCalled: false }
+
+  await openBrowser('http://localhost:5173', {
+    platform: 'linux',
+    execFileRef(command, args, options, callback) {
+      call.command = command
+      call.args = args
+      call.options = options
+
+      queueMicrotask(() => callback(null))
+
+      return {
+        unref() {
+          call.unrefCalled = true
+        }
+      }
+    }
+  })
+
+  assert.equal(call.command, 'xdg-open')
+  assert.deepEqual(call.args, ['http://localhost:5173'])
+  assert.deepEqual(call.options, { windowsHide: true })
+  assert.equal(call.unrefCalled, true)
+})
+
+test('openBrowser rejects when the opener command fails', async () => {
+  const error = new Error('spawn xdg-open ENOENT')
+
+  await assert.rejects(
+    openBrowser('http://localhost:5173', {
+      platform: 'linux',
+      execFileRef(_command, _args, _options, callback) {
+        queueMicrotask(() => callback(error))
+        return {
+          unref() {}
+        }
+      }
+    }),
+    /spawn xdg-open ENOENT/
+  )
+})


### PR DESCRIPTION
## What changed
- replace the brittle browser opener with platform-aware command dispatch for macOS, Linux, and Windows
- quote the Windows preview URL correctly so query params survive the `cmd start` hop
- surface browser-launch failures with a clear manual fallback URL
- add focused tests for platform dispatch and opener success/failure behavior

## Verification
- npm test
- npm run typecheck

Closes #33
Fixes #33
Resolves #33